### PR TITLE
Allow setting pods dir path with env vars

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,7 +37,7 @@ from dotenv import load_dotenv
 app.config.from_object('config')
 
 load_dotenv()
-LANGS = os.getenv('PEARS_LANGS').split(',')
+LANGS = os.getenv('PEARS_LANGS', "en").split(',')
 app.config['MAIL_DEFAULT_SENDER'] = os.getenv("MAIL_DEFAULT_SENDER")
 app.config['MAIL_SERVER'] = os.getenv("MAIL_SERVER")
 app.config['MAIL_PORT'] = os.getenv("MAIL_PORT")
@@ -49,6 +49,7 @@ app.config['MAIL_PASSWORD'] = os.getenv("EMAIL_PASSWORD")
 app.config['SITENAME'] = os.getenv("SITENAME")
 app.config['SITE_TOPIC'] = os.getenv("SITE_TOPIC")
 app.config['SEARCH_PLACEHOLDER'] = os.getenv("SEARCH_PLACEHOLDER")
+app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv("SQLALCHEMY_DATABASE_URI", app.config.get("SQLALCHEMY_DATABASE_URI"))
 
 # Localization
 from flask_babel import Babel, gettext

--- a/app/cli/controllers.py
+++ b/app/cli/controllers.py
@@ -7,6 +7,7 @@ from os.path import dirname, realpath, join
 from datetime import datetime
 from pathlib import Path
 import joblib
+import os
 from urllib.parse import urlparse
 from random import shuffle
 from flask import Blueprint
@@ -23,8 +24,7 @@ from app import db, User, Urls, Pods
 pears = Blueprint('pears', __name__)
 
 dir_path = dirname(dirname(dirname(realpath(__file__))))
-pod_dir = join(dir_path,'app','static','pods')
-
+pod_dir = os.getenv("PODS_DIR", os.path.join(dir_path, 'app','static','pods'))
 
 @pears.cli.command('setadmin')
 @click.argument('username')
@@ -48,8 +48,6 @@ def index(host_url, filepath):
     with one url per line.
     Use from CLI with flask pears index <contributor> <path>
     '''
-    dir_path = dirname(dirname(dirname(realpath(__file__))))
-    pod_dir = join(dir_path,'app','static','pods')
     users = User.query.all()
     for user in users:
         Path(join(pod_dir,user.username)).mkdir(parents=True, exist_ok=True)
@@ -98,8 +96,6 @@ def legacy_export_urls(user):
 @click.argument('backupdir')
 def backup(backupdir):
     '''Backup database and pods to specified directory'''
-    dir_path = dirname(dirname(dirname(realpath(__file__))))
-    pod_dir = join(dir_path,'app','static','pods')
     #Check if directory exists, otherwise create it
     Path(backupdir).mkdir(parents=True, exist_ok=True)
     #Get today's date


### PR DESCRIPTION
This PR makes the pods dir configurable using env vars. This is necessary because we want to preserve this directory when using docker for deployment and we should be able to configure this path. If the environment variable is not set, the default behavior of it (storing in `app/static/pods`) is maintained