### PR TITLE
Allow using env vars for userdata

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -69,7 +69,7 @@ app.config.from_object('config')
 
 load_dotenv()
 LANGS = os.getenv('PEARS_LANGS', "en").split(',')
-OWN_BRAND = True if os.getenv('OWN_BRAND').lower() == 'true' else False
+OWN_BRAND = True if os.getenv('OWN_BRAND', "false").lower() == 'true' else False
 app.config['MAIL_DEFAULT_SENDER'] = os.getenv("MAIL_DEFAULT_SENDER")
 app.config['MAIL_SERVER'] = os.getenv("MAIL_SERVER")
 app.config['MAIL_PORT'] = os.getenv("MAIL_PORT")
@@ -89,7 +89,7 @@ app.config['ORG_NAME'] = os.getenv("ORG_NAME")
 app.config['ORG_ADDRESS'] = os.getenv("ORG_ADDRESS")
 app.config['ORG_EMAIL'] = os.getenv("ORG_EMAIL")
 app.config['APPLICABLE_LAW'] = os.getenv("APPLICABLE_LAW")
-app.config['EU_SPECIFIC'] = True if os.getenv("EU_SPECIFIC").lower() == 'true' else False
+app.config['EU_SPECIFIC'] = True if os.getenv("EU_SPECIFIC", "false").lower() == 'true' else False
 
 # Localization
 from flask_babel import Babel, gettext

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -100,6 +100,8 @@ babel = Babel(app)
 # Make sure user data directories exist
 DEFAULT_PATH = f'app'
 Path(os.path.join(DEFAULT_PATH,'static/userdata')).mkdir(parents=True, exist_ok=True)
+if os.getenv("SUGGESTIONS_DIR", "") != "":
+    Path(os.getenv("SUGGESTIONS_DIR")).mkdir(parents=True, exist_ok=True)
 
 # Mail
 mail = Mail(app)

--- a/app/api/controllers.py
+++ b/app/api/controllers.py
@@ -5,7 +5,7 @@
 import joblib
 import json
 import numpy as np
-from os import remove
+from os import remove, getenv
 from os.path import dirname, join, realpath, isfile
 from flask import Blueprint, jsonify, request, render_template, url_for
 from flask_login import login_required
@@ -23,7 +23,7 @@ from app.utils_db import load_idx_to_url, load_npz_to_idx, rm_from_idx_to_url, d
 api = Blueprint('api', __name__, url_prefix='/api')
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 @api.route('/languages/', methods=["GET", "POST"])
 def return_instance_languages():

--- a/app/api/controllers.py
+++ b/app/api/controllers.py
@@ -23,7 +23,7 @@ from app.utils_db import load_idx_to_url, load_npz_to_idx, rm_from_idx_to_url, d
 api = Blueprint('api', __name__, url_prefix='/api')
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = join(dir_path,'static','pods')
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 @api.route('/languages/', methods=["GET", "POST"])
 def return_instance_languages():

--- a/app/cli/controllers.py
+++ b/app/cli/controllers.py
@@ -4,6 +4,7 @@
 
 from shutil import copy2, copytree
 from os.path import dirname, realpath, join
+from os import getenv
 from datetime import datetime
 from pathlib import Path
 import joblib
@@ -23,8 +24,8 @@ from app import db, User, Urls, Pods
 pears = Blueprint('pears', __name__)
 
 dir_path = dirname(dirname(dirname(realpath(__file__))))
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'app','static','pods'))
-user_dir = os.getenv("SUGGESTIONS_DIR", join(dir_path, 'app' 'static', 'userdata'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'app','static','pods'))
+user_dir = getenv("SUGGESTIONS_DIR", join(dir_path, 'app' 'static', 'userdata'))
 
 @pears.cli.command('setadmin')
 @click.argument('username')

--- a/app/cli/controllers.py
+++ b/app/cli/controllers.py
@@ -7,7 +7,6 @@ from os.path import dirname, realpath, join
 from datetime import datetime
 from pathlib import Path
 import joblib
-import os
 from urllib.parse import urlparse
 from random import shuffle
 from flask import Blueprint
@@ -24,7 +23,8 @@ from app import db, User, Urls, Pods
 pears = Blueprint('pears', __name__)
 
 dir_path = dirname(dirname(dirname(realpath(__file__))))
-pod_dir = os.getenv("PODS_DIR", os.path.join(dir_path, 'app','static','pods'))
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'app','static','pods'))
+user_dir = os.getenv("SUGGESTIONS_DIR", join(dir_path, 'app' 'static', 'userdata'))
 
 @pears.cli.command('setadmin')
 @click.argument('username')
@@ -71,8 +71,6 @@ def get_links(url):
 @pears.cli.command('exporturls')
 def export_urls():
     '''Get all URLs on this instance'''
-    dir_path = dirname(dirname(dirname(realpath(__file__))))
-    user_dir = join(dir_path,'app','static','userdata')
     date = datetime.now().strftime('%Y-%m-%d-%Hh%Mm')
     filepath = join(user_dir,"admin."+date+".pears.txt")
     urls = []

--- a/app/indexer/controllers.py
+++ b/app/indexer/controllers.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import logging
+from os import getenv
 from os.path import dirname, join, realpath
 from time import sleep
 import hashlib
@@ -23,7 +24,7 @@ from app.indexer.posix import posix_doc
 from app.forms import IndexerForm, ManualEntryForm
 
 app_dir_path = dirname(dirname(realpath(__file__)))
-suggestions_dir_path = os.getenv("SUGGESTIONS_DIR", join(app_dir_path, 'static', 'userdata'))
+suggestions_dir_path = getenv("SUGGESTIONS_DIR", join(app_dir_path, 'static', 'userdata'))
 
 # Define the blueprint:
 indexer = Blueprint('indexer', __name__, url_prefix='/indexer')

--- a/app/indexer/controllers.py
+++ b/app/indexer/controllers.py
@@ -23,7 +23,7 @@ from app.indexer.posix import posix_doc
 from app.forms import IndexerForm, ManualEntryForm
 
 app_dir_path = dirname(dirname(realpath(__file__)))
-suggestions_dir_path = join(app_dir_path,'static', 'userdata')
+suggestions_dir_path = os.getenv("SUGGESTIONS_DIR", join(app_dir_path, 'static', 'userdata'))
 
 # Define the blueprint:
 indexer = Blueprint('indexer', __name__, url_prefix='/indexer')

--- a/app/indexer/mk_page_vector.py
+++ b/app/indexer/mk_page_vector.py
@@ -4,6 +4,7 @@
 
 import logging
 from os.path import dirname, join, realpath
+from os import getenv
 import numpy as np
 from scipy.sparse import csr_matrix, vstack, save_npz, load_npz
 from app import models, VEC_SIZE, DEFAULT_PATH
@@ -15,7 +16,7 @@ from app.utils import timer
 from app.utils_db import create_pod_npz_pos
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 def tokenize_text(text, lang, stringify = True):
     """ Load the SentencePiece model included in the install

--- a/app/indexer/mk_page_vector.py
+++ b/app/indexer/mk_page_vector.py
@@ -15,7 +15,7 @@ from app.utils import timer
 from app.utils_db import create_pod_npz_pos
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = join(dir_path,'static','pods')
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 def tokenize_text(text, lang, stringify = True):
     """ Load the SentencePiece model included in the install

--- a/app/orchard/mk_urls_file.py
+++ b/app/orchard/mk_urls_file.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from os.path import dirname, realpath, join
+from os import getenv
 from flask import request
 from app.api.models import Urls
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 
 def get_url_list_for_users(theme):

--- a/app/orchard/mk_urls_file.py
+++ b/app/orchard/mk_urls_file.py
@@ -7,7 +7,7 @@ from flask import request
 from app.api.models import Urls
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = join(dir_path,'static','pods')
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 
 def get_url_list_for_users(theme):

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -21,7 +21,7 @@ search = Blueprint('search', __name__, url_prefix='')
 
 dir_path = dirname(dirname(dirname(realpath(__file__))))
 static_dir = join(dir_path,'app','static')
-pod_dir = join(dir_path,'app','static','pods')
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 
 @search.context_processor

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import logging
+from os import getenv
 from os.path import dirname, join, realpath
 from glob import glob
 import numpy as np
@@ -21,7 +22,7 @@ search = Blueprint('search', __name__, url_prefix='')
 
 dir_path = dirname(dirname(dirname(realpath(__file__))))
 static_dir = join(dir_path,'app','static')
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 
 @search.context_processor

--- a/app/search/score_pages.py
+++ b/app/search/score_pages.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
+from os import getenv
 from os.path import dirname, join, realpath
 import logging
 import math
@@ -25,7 +26,7 @@ from app.indexer.mk_page_vector import compute_query_vectors
 from app.indexer.posix import load_posix
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 def intersect_best_pods_lists(query_vectors, podsum, podnames):
     """ Iterate through each word in the query (a vector of tokens)

--- a/app/search/score_pages.py
+++ b/app/search/score_pages.py
@@ -25,7 +25,7 @@ from app.indexer.mk_page_vector import compute_query_vectors
 from app.indexer.posix import load_posix
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = join(dir_path,'static','pods')
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 def intersect_best_pods_lists(query_vectors, podsum, podnames):
     """ Iterate through each word in the query (a vector of tokens)

--- a/app/settings/controllers.py
+++ b/app/settings/controllers.py
@@ -6,7 +6,7 @@
 # Import flask dependencies
 import logging
 from glob import glob
-from os import rename
+from os import rename, getenv
 from os.path import dirname, realpath, join, isdir, exists
 from flask import Blueprint, flash, request, render_template, redirect, url_for, session
 from flask_login import login_required, current_user, logout_user
@@ -24,7 +24,7 @@ from app.auth.token import send_email
 settings = Blueprint('settings', __name__, url_prefix='/settings')
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 
 @settings.context_processor

--- a/app/settings/controllers.py
+++ b/app/settings/controllers.py
@@ -24,7 +24,7 @@ from app.auth.token import send_email
 settings = Blueprint('settings', __name__, url_prefix='/settings')
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = join(dir_path,'static','pods')
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'static','pods'))
 
 
 @settings.context_processor

--- a/app/utils_db.py
+++ b/app/utils_db.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import logging
-from os import remove, rename
+from os import remove, rename, getenv
 from os.path import dirname, realpath, join, isfile
 from pathlib import Path
 from string import punctuation
@@ -15,7 +15,7 @@ from app.api.models import Urls, Pods
 from app.indexer.posix import load_posix, dump_posix
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = os.getenv("PODS_DIR", join(dir_path, 'app', 'static','pods'))
+pod_dir = getenv("PODS_DIR", join(dir_path, 'app', 'static','pods'))
 
 def parse_pod_name(pod_name):
     logging.debug(f">> UTILS_DB: parse_pod_name: {pod_name}")

--- a/app/utils_db.py
+++ b/app/utils_db.py
@@ -15,7 +15,7 @@ from app.api.models import Urls, Pods
 from app.indexer.posix import load_posix, dump_posix
 
 dir_path = dirname(dirname(realpath(__file__)))
-pod_dir = join(dir_path,'app','static','pods')
+pod_dir = os.getenv("PODS_DIR", join(dir_path, 'app', 'static','pods'))
 
 def parse_pod_name(pod_name):
     logging.debug(f">> UTILS_DB: parse_pod_name: {pod_name}")


### PR DESCRIPTION
Following up on #15, this PR makes the `userdata` dir backup-able. Along side this PR fixes some `pods_dir` replacement that I overlooked in my last PR. 

I am also setting default values for `EU_SPECIFIC` and `OWN_BRAND` env vars variables for the ease of deployment.