### PR TITLE
use apt instead of pip install for virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you haven't yet set up virtualenv on your machine, please install it via pip:
 
     sudo apt-get install python3-pip
 
-    sudo pip install virtualenv
+    sudo apt install python3-virtualenv
 
 Then change into the PeARS-orchard directory:
 


### PR DESCRIPTION
on debian, perhaps also ubuntu, using pip with sudo requires `--break-system-packages` option which could be bad

instead, we can use apt to install it ! :)

