### PR TITLE
Add 'create-user' CLI command to create a user account

### DIFF
--- a/app/cli/controllers.py
+++ b/app/cli/controllers.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 from random import shuffle
 from flask import Blueprint
 import click
+from werkzeug.security import generate_password_hash
 from scipy.sparse import load_npz
 from app.indexer.controllers import run_indexer_url
 from app.indexer.access import request_url
@@ -36,6 +37,23 @@ def set_admin(username):
     db.session.commit()
     print(username,"is now admin.")
 
+@pears.cli.command('create-user')
+@click.argument('username')
+@click.argument('password')
+@click.argument('email')
+def create_user(username, password, email):
+    '''
+    Creates a user with provided username, password and email.
+    This user is not admin and their email address is automatically confirmed.
+    '''
+    user = User(username=username,
+                password=generate_password_hash(password, method='scrypt'),
+                email=email,
+                is_confirmed=True,
+                confirmed_on=datetime.now())
+    db.session.add(user)
+    db.session.commit()
+    print(username, "has been registered.")
 
 @pears.cli.command('index')
 @click.argument('host_url')


### PR DESCRIPTION
Implements https://github.com/PeARSearch/PeARS-federated/issues/35

Pretty basic `flask pears create-user USERNAME PASSWORD EMAIL` command. The user is registered with their email marked as "confirmed".