### PR TITLE
Set session cookie to secure

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -12,6 +12,7 @@ export EMAIL_PASSWORD=<your password>
 # Secrets
 export SECRET_KEY=<some long string>
 export SECURITY_PASSWORD_SALT=<some other long string>
+export CSRF_SESSION_KEY=<yet another long string>
 
 # Pod settings
 #export PODS_DIR=<the full path to your pod directory>

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -91,7 +91,6 @@ app.config['USER-AGENT'] = "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; c
 # Secrets
 app.config['SECRET_KEY'] = getenv("SECRET_KEY")                         
 app.config['SECURITY_PASSWORD_SALT'] = getenv("SECURITY_PASSWORD_SALT")
-app.config['SESSION_COOKIE_SECURE'] = True
 app.config['SESSION_COOKIE_HTTPONLY'] = False
 app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
 app.config['CSRF_ENABLED'] = True

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -73,6 +73,7 @@ from dotenv import load_dotenv
 app.config.from_object('config')
 
 load_dotenv()
+app.config['SESSION_COOKIE_SECURE'] = True
 app.config['MAIL_DEFAULT_SENDER'] = getenv("MAIL_DEFAULT_SENDER")
 app.config['MAIL_SERVER'] = getenv("MAIL_SERVER")
 app.config['MAIL_PORT'] = getenv("MAIL_PORT")
@@ -85,7 +86,16 @@ app.config['SITENAME'] = getenv("SITENAME")
 app.config['SITE_TOPIC'] = getenv("SITE_TOPIC")
 app.config['SEARCH_PLACEHOLDER'] = getenv("SEARCH_PLACEHOLDER")
 app.config['SQLALCHEMY_DATABASE_URI'] = getenv("SQLALCHEMY_DATABASE_URI", app.config.get("SQLALCHEMY_DATABASE_URI"))
-app.config['USER-AGENT'] = "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PeARSbot/0.1; +https://www.pearsproject.org/) Chrome/W.X.Y.Z Safari/537.36"
+app.config['USER-AGENT'] = "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PeARSbot/0.1; +https://www.pearsproject.org/) Chrome/126.0.6478.114 Safari/537.36"
+
+# Secrets
+app.config['SECRET_KEY'] = getenv("SECRET_KEY")                         
+app.config['SECURITY_PASSWORD_SALT'] = getenv("SECURITY_PASSWORD_SALT")
+app.config['SESSION_COOKIE_SECURE'] = True
+app.config['SESSION_COOKIE_HTTPONLY'] = False
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
+app.config['CSRF_ENABLED'] = True
+app.config['CSRF_SESSION_KEY'] = getenv("CSRF_SESSION_KEY")
 
 # Legal
 app.config['ORG_NAME'] = getenv("ORG_NAME")

--- a/app/__init_for_pythonanywhere__.py
+++ b/app/__init_for_pythonanywhere__.py
@@ -83,11 +83,16 @@ app.config['SITENAME'] = getenv("SITENAME")
 app.config['SITE_TOPIC'] = getenv("SITE_TOPIC")
 app.config['SEARCH_PLACEHOLDER'] = getenv("SEARCH_PLACEHOLDER")
 app.config['SQLALCHEMY_DATABASE_URI'] = getenv("SQLALCHEMY_DATABASE_URI", app.config.get("SQLALCHEMY_DATABASE_URI"))
-app.config['USER-AGENT'] = "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PeARSbot/0.1; +https://www.pearsproject.org/) Chrome/W.X.Y.Z Safari/537.36"
+app.config['USER-AGENT'] = "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PeARSbot/0.1; +https://www.pearsproject.org/) Chrome/126.0.6478.114 Safari/537.36"
 
 # Secrets
-app.config['SECRET_KEY'] = getenv("SECRET_KEY")                         # set in .env file
-app.config['SECURITY_PASSWORD_SALT'] = getenv("SECURITY_PASSWORD_SALT") # set in .env file
+app.config['SECRET_KEY'] = getenv("SECRET_KEY")                         
+app.config['SECURITY_PASSWORD_SALT'] = getenv("SECURITY_PASSWORD_SALT")
+app.config['SESSION_COOKIE_SECURE'] = True
+app.config['SESSION_COOKIE_HTTPONLY'] = False
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
+app.config['CSRF_ENABLED'] = True
+app.config['CSRF_SESSION_KEY'] = getenv("CSRF_SESSION_KEY")
 
 # Legal
 app.config['ORG_NAME'] = getenv("ORG_NAME")

--- a/config.py
+++ b/config.py
@@ -22,16 +22,5 @@ DATABASE_CONNECT_OPTIONS = {}
 # operations using the other.
 THREADS_PER_PAGE = 2
 
-# Enable protection agains *Cross-site Request Forgery (CSRF)*
-CSRF_ENABLED = True
-
-# Use a secure, unique and absolutely secret key for
-# signing the data.
-CSRF_SESSION_KEY = "secret"
-
-# Secrets
-SECRET_KEY = config("SECRET_KEY", default="very-important")
-SECURITY_PASSWORD_SALT = config("SECURITY_PASSWORD_SALT", default="very-important")
-
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 


### PR DESCRIPTION
Set session cookie to secure=True, httponly=False, and samesite=Lax.

Cleaned up the config file. I am putting the CSRF stuff in init so that both init files (standard one and pythonanywhere one) follow the same format.

Minor fix in user-agent string: Chrome did not have a version number.