### PR TITLE
Restructured app

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -47,6 +47,7 @@ class Urls(Base):
     title = db.Column(db.String(1000))
     snippet = db.Column(db.String(1000))
     doctype = db.Column(db.String(1000))
+    vector = db.Column(db.Integer)
     pod = db.Column(db.String(1000))
     notes = db.Column(db.String(1000))
     img = db.Column(db.String(1000))
@@ -58,6 +59,7 @@ class Urls(Base):
                  title=None,
                  snippet=None,
                  doctype=None,
+                 vector=None,
                  pod=None,
                  notes=None,
                  img=None,
@@ -67,6 +69,7 @@ class Urls(Base):
         self.title = title
         self.snippet = snippet
         self.doctype = doctype
+        self.vector = vector
         self.pod = pod
         self.notes = notes
         self.img = img
@@ -84,6 +87,7 @@ class Urls(Base):
             'title': self.title,
             'snippet': self.snippet,
             'doctype': self.doctype,
+            'vector': self.vector,
             'pod': self.pod,
             'notes': self.notes,
             'img': self.img,

--- a/app/cli/controllers.py
+++ b/app/cli/controllers.py
@@ -5,7 +5,8 @@
 import re
 import requests
 from shutil import copy2, copytree
-from os.path import dirname, realpath, join
+from os import remove
+from os.path import dirname, realpath, join, exists
 from os import getenv
 from glob import glob
 from datetime import datetime
@@ -13,18 +14,18 @@ from pathlib import Path
 from random import shuffle
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup
+import numpy as np
 import joblib
 from flask import Blueprint
 import click
 from werkzeug.security import generate_password_hash
-from scipy.sparse import load_npz
+from scipy.sparse import load_npz, save_npz, csr_matrix, vstack
 from app.indexer.controllers import run_indexer_url, index_doc_from_cli
 from app.indexer.access import request_url
 from app.indexer.posix import load_posix
 from app.indexer.htmlparser import extract_links
 from app.orchard.mk_urls_file import get_reindexable_pod_for_admin
-from app.utils_db import create_idx_to_url
-from app import db, User, Urls, Pods
+from app import db, User, Urls, Pods, VEC_SIZE
 
 pears = Blueprint('pears', __name__)
 
@@ -160,7 +161,6 @@ def index(host_url, filepath):
     users = User.query.all()
     for user in users:
         Path(join(pod_dir,user.username)).mkdir(parents=True, exist_ok=True)
-        create_idx_to_url(user.username)
     run_indexer_url(filepath, host_url)
 
 
@@ -227,7 +227,7 @@ def index_wiki(folder, regex, lang, contributor, host_url):
     - host_url: the domain of your instance, e.g. https://mypears.org.
 
     '''
-    corpus_files = glob(join(folder, regex ,'*.doc.txt'))
+    corpus_files = glob(join(folder, f'*{regex}*', '*.doc.txt'))
     for filepath in corpus_files:
         print(f">>Processing {filepath}...")
         with open(filepath, encoding='utf-8') as fin:
@@ -246,7 +246,8 @@ def index_wiki(folder, regex, lang, contributor, host_url):
                 elif "</doc" in l:
                     print(url,theme,title,doc[:30])
                     note = ""
-                    index_doc_from_cli(title, doc, theme, lang, contributor, url, note, host_url)
+                    if not title.startswith("Talk:"):
+                        index_doc_from_cli(title, doc, theme, lang, contributor, url, note, host_url)
                     doc = ""
                 else:
                     doc+=l+' '
@@ -401,3 +402,79 @@ def check_pos_vs_npz_to_idx(pod, username, language):
         print("\t\t> idx  :", set(idx1))
         print("\t\t> posix:", set(idx2))
     return set(idx1), set(idx2)
+
+#####################
+# REBUILD FROM DB
+#####################
+
+@pears.cli.command('rebuildfromdb')
+def rebuild_from_db():
+    idx_paths = []
+    pods = Pods.query.all()
+    for p in pods:
+        print(f"\n\n POD {p.name}")
+        m = np.zeros((1,VEC_SIZE))
+        m = csr_matrix(m)
+        try:
+            urls = db.session.query(Urls).filter_by(pod=p.name).all()
+            username = p.name.split('.u.')[1]
+            idx_path = join(pod_dir, username, username+'.idx')
+            if idx_path not in idx_paths:
+                idx_paths.append(idx_path)
+            idx_to_url = joblib.load(idx_path)
+        except:
+            print(f">> ERROR: CLI: REBUILD FROM DB: npz.idx for {p.name} is corrupted.")
+            print(f">> ERROR: CLI: REBUILD FROM DB: deleting pod {p.name} from the database.")
+            db.session.delete(p)
+            db.session.commit()
+            continue
+        
+        try:
+            npz_idx_path = join(pod_dir, username, p.language, p.name+'.npz.idx')
+            npz_to_idx = joblib.load(npz_idx_path)
+        except:
+            print(f">> ERROR: CLI: REBUILD FROM DB: npz.idx for {p.name} does not exist.")
+            print(f">> ERROR: CLI: REBUILD FROM DB: deleting pod {p.name} from the database.")
+            db.session.delete(p)
+            db.session.commit()
+            continue
+
+        try:
+            npz_path = join(pod_dir, username, p.language, p.name+'.npz')
+            npz = load_npz(npz_path).toarray()
+        except:
+            print(f">> ERROR: CLI: REBUILD FROM DB: npz for {p.name} does not exist.")
+            print(f">> ERROR: CLI: REBUILD FROM DB: deleting pod {p.name} from the database.")
+            db.session.delete(p)
+            db.session.commit()
+            continue
+
+        for u in urls:
+            row = None
+            try:
+                k = idx_to_url[1].index(u.url)
+                idx = idx_to_url[0][k]
+                k = npz_to_idx[1].index(idx)
+                row = npz_to_idx[0][k]
+                v = npz[row]
+            except:
+                print(f">> ERROR: CLI: REBUILD FROM DB: matrix row not found for url {u.url}.")
+                print(f">> ERROR: CLI: REBUILD FROM DB: deleting url {u.url} from the database.")
+                db.session.delete(u)
+                db.session.commit()
+                continue
+            m = vstack((m,v))
+            u.vector = m.shape[0]-1
+            db.session.add(u)
+            db.session.commit()
+
+        # Clean up: save new npz and remove unused files
+        save_npz(npz_path, m)
+        remove(npz_idx_path)
+
+        pos_path = join(pod_dir, username, p.language, p.name+'.pos')
+        if exists(pos_path):
+            remove(pos_path)
+
+    for idx_path in idx_paths:
+        remove(idx_path)

--- a/app/indexer/mk_page_vector.py
+++ b/app/indexer/mk_page_vector.py
@@ -72,8 +72,8 @@ def compute_vector(url, theme, contributor, url_type):
         pod_m, success = compute_and_stack_new_vec(lang, tokenized_text, pod_m)
         if success:
             save_npz(npz_path,pod_m)
-            vid = pod_m.shape[0]
-            return True, tokenized_text, lang, title, snippet, vid, messages
+            idv = pod_m.shape[0]-1
+            return True, tokenized_text, lang, title, snippet, idv, messages
     messages.append(">> INDEXER ERROR: compute_vectors: error during parsing")
     return False, None, None, None, None, None, messages
 
@@ -82,7 +82,8 @@ def compute_vector_local_docs(title, doc, theme, lang, contributor):
     """ Compute vector for manual document and add it to the matrix
     for the user's chosen theme.
     """
-    npz_path = join(pod_dir,contributor, lang, theme+'.u.'+contributor+'.npz')
+    user_dir = join(pod_dir, contributor, lang)
+    npz_path = join(user_dir,theme+'.u.'+contributor+'.npz')
     pod_m = load_npz(npz_path)
     #print("Computing vectors for", target_url, "(",theme,")",lang)
     text = title + ". " + theme + ". " + doc
@@ -94,7 +95,7 @@ def compute_vector_local_docs(title, doc, theme, lang, contributor):
         snippet = title
     if success:
         save_npz(npz_path,pod_m)
-        vid = pod_m.shape[0]
+        vid = pod_m.shape[0]-1
         return True, text, snippet, vid
     return False, text, snippet, None
 

--- a/app/indexer/pdfparser.py
+++ b/app/indexer/pdfparser.py
@@ -19,7 +19,6 @@ from app.api.models import installed_languages
 from app.utils import remove_emails
 
 app_dir_path = dirname(dirname(realpath(__file__)))
-suggestions_dir_path = getenv("SUGGESTIONS_DIR", join(app_dir_path, 'userdata'))
 
 
 def pdf_mine(pdf_path, max_pages = 12):
@@ -30,11 +29,13 @@ def pdf_mine(pdf_path, max_pages = 12):
     title = metadata[0]['Title'].decode(encoding='utf-8', errors='ignore').replace('\x00', '')
     #authors = metadata[0]['Author'].decode(encoding='utf-8', errors='ignore').replace('\x00', '')
     if which('pdftotext') is not None:
+        print("Indexing with installed pdftotext")
         subprocess.call(['pdftotext', '-l', str(max_pages), pdf_path])
         txt_path = pdf_path.replace('.pdf','.txt')
         with open(txt_path, 'r') as ftxt:
             body = ftxt.read().replace('\n', ' ')
     else:
+        print("Indexing with pdfminer")
         c = 0
         for page_layout in extract_pages(pdf_path):
             for element in page_layout:
@@ -59,7 +60,7 @@ def extract_txt(url, contributor):
     language = app.config['LANGS'][0]
     error = None
     snippet_length = app.config['SNIPPET_LENGTH']
-    local_pdf_path = join(suggestions_dir_path, contributor+'.'+url.split('/')[-1])
+    local_pdf_path = join(app_dir_path, 'userdata', contributor+'.'+url.split('/')[-1])
     try:
         req = requests.get(url, allow_redirects=True, timeout=30)
         req.encoding = 'utf-8'

--- a/app/settings/controllers.py
+++ b/app/settings/controllers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
+# SPDX-FileCopyrightText: 2024 PeARS Project, <community@pearsproject.org>, 
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -14,7 +14,6 @@ from flask_babel import gettext
 from app import app, db
 from app.api.models import Urls, User
 from app.forms import EmailChangeForm, UsernameChangeForm
-from app.api.controllers import return_url_delete
 from app.utils_db import delete_url_representations
 from app.auth.decorators import check_is_confirmed
 from app.auth.token import send_email
@@ -165,8 +164,7 @@ def delete_account():
     current_user.remove()
     db.session.commit()
     flash(gettext("Your account has successfully been deleted."), "success")
-    placeholder = app.config['SEARCH_PLACEHOLDER']
-    return render_template('search/index.html', own_brand=OWN_BRAND, placeholder=placeholder)
+    return redirect(url_for("search.index"))
 
 
 @settings.route('/change_email', methods=['POST'])

--- a/app/templates/admin/pears_list.html
+++ b/app/templates/admin/pears_list.html
@@ -41,5 +41,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 
     <div class="container">
     {{ super() }}
+    <style>
+        .select2-results {
+            max-height: 400px !important;
+        }
+
+        .select2-container {
+            width: 400px !important;
+        }
+    </style>
     </div>
 {% endblock %}

--- a/app/templates/search/results.html
+++ b/app/templates/search/results.html
@@ -15,22 +15,21 @@ SPDX-License-Identifier: AGPL-3.0-only
           <div class="alert alert-info alert-dismissible">
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
             <div class="d-flex justify-content-start">
-	            {% if session.get('theme') == 'dark' %}
-	             <img src="{{ url_for('static', filename='happy_pears_dark.png')}}" width="40px" style="margin-right:10px">
-	            {% else %}
-	              <img src="{{ url_for('static', filename='happy_pears.png')}}" width="40px" style="margin-right:10px">
+	      {% if session.get('theme') == 'dark' %}
+	        <img src="{{ url_for('static', filename='happy_pears_dark.png')}}" width="40px" style="margin-right:10px">
+	      {% else %}
+	        <img src="{{ url_for('static', filename='happy_pears.png')}}" width="40px" style="margin-right:10px">
               {% endif %}
-            
-	            {{internal_message}}
+	      {{internal_message}}
             </div>
-	        </div>
+	  </div>
         </div>     
         {% endif %}
       <form method="POST" action="{{url_for('search.index')}}" enctype="multipart/form-data" id='searchform'>
         {{ searchform.hidden_tag() }}
         <div class="input-group group mt-4" >
           {{ render_search_field(searchform.query, placeholder) }}
-	        <button class="btn btn-lg btn-success" type="submit" id='searchbutton'><ion-icon name="search-outline"></ion-icon></button>
+	  <button class="btn btn-lg btn-success" type="submit" id='searchbutton'><ion-icon name="search-outline"></ion-icon></button>
           <button class="btn btn-lg btn-success" type="button" id='loadingbutton' style='display:none'>
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
           </button>
@@ -39,54 +38,56 @@ SPDX-License-Identifier: AGPL-3.0-only
       {% if config['FEEDBACK_FORM'] %}
         <p class="small">Help us improve this alpha version of PeARS! <a href={{url_for('orchard.feedback')}}>Send us your feedback.</a></p>
       {% endif %}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-10">
-	    {% if results == None %}
-	      <p>{{gettext('<b>No results found.</b><br> The reason for this could be that the topic of this PeARS instance is not aligned with your query. 
-	  It could also be that its index is still too small! We would be happy if you contributed to the index by adding your favourite URLs
-	  on your topic.')}}</p>
-	      <br><p>{{gettext('No account yet?')}} <a href={{url_for('auth.signup')}}>{{gettext('Sign up')}}</a></p>
-	    {% else %}
-	      <h3>{{gettext('Search results:')}}</h3>
-        {% for result in results %}
-        <div class="card mt-2">
-          <div class="card-body" style="padding: 20px 0px 20px 0px">
-	          <div class="d-flex justify-content-between">
-		          <div><ion-icon name="globe"></ion-icon> <a href="{{result[1]}}" style="text-decoration: none; font-size: large"><b>{{result[2]}}</b></a></div>
-	            <div>
-	              <a class="btn btn-link" href="{{url_for('orchard.annotate')}}?url={{result[1]}}" data-toggle="tooltip" title="{{gettext('Add a note to this entry')}}"><ion-icon name="chatbubble-outline"></ion-icon></a>  
-	              <a class="btn btn-link" href="{{url_for('orchard.report')}}?url={{result[1]}}"  data-toggle="tooltip" title="{{gettext('Report this entry')}}"><ion-icon name="flag-outline"></ion-icon></a> 
-	              <button class="btn btn-link" data-toggle="tooltip" title="{{gettext('Share this entry')}}" onClick="copyToClipboard('{{result[8]}}', 'copy{{result[0]}}')" id="copy{{result[0]}}"><ion-icon name="share-outline"></ion-icon></button> 
-              </div>
-            </div>
-	          <p class="card-text small"><a href="{{result[1]}}" class="card-link">{{result[1]}}</a></p><!-- explicit link-->
-	          <p class="card-text small" style="margin-top:-10px">
-              <br>{{result[3]|safe}}<!--snippet-->
-              {% if result[6] != None %}
-	              <button class="btn btn-link collapsed" data-bs-toggle="collapse" data-bs-target="#collapse{{result[0]}}" aria-expanded="false" aria-controls="collapse{{result[0]}}">
-	              <img src="{{ url_for('static', filename='note.png')}}" width='30px' />
-                </button>
-              {% endif %}
-            </p>
-            {% if result[6] != None %}<!-- note -->
-              <div class="collapse" id="collapse{{result[0]}}">
-                <p class="card-text small">
-	              {% for note in result[6] %}
-	                {{note}}<br>
-	              {% endfor %}
-	              </p>
-	            </div><!-- note -->
-	          {% endif %}
-            <hr>
-	        </div><!-- div card-body -->
-	      </div><!-- div card mt-2 -->
-        {% endfor %}
-      {% endif %}
       </div><!-- col -->
     </div><!-- row -->
-  </div>
+
+    <div class="row">
+      <div class="col-md-10">
+        {% if results == None %}
+	  <p>{{gettext('<b>No results found.</b><br> The reason for this could be that the topic of this PeARS instance is not aligned with your query. 
+	  It could also be that its index is still too small! We would be happy if you contributed to the index by adding your favourite URLs
+	  on your topic.')}}</p>
+	  <br><p>{{gettext('No account yet?')}} <a href={{url_for('auth.signup')}}>{{gettext('Sign up')}}</a></p>
+	{% else %}
+	  <h3>{{gettext('Search results:')}}</h3>
+          {% for result in results %}
+          <div class="card mt-2">
+            <div class="card-body" style="padding: 20px 0px 20px 0px">
+              <div class="d-flex justify-content-between"><!-- card header: links -->
+	        <div><ion-icon name="globe"></ion-icon> <a href="{{result[1]}}" style="text-decoration: none; font-size: large"><b>{{result[2]}}</b></a></div>
+	        <div>
+	          <a class="btn btn-link" href="{{url_for('orchard.annotate')}}?url={{result[1]}}" data-toggle="tooltip" title="{{gettext('Add a note to this entry')}}"><ion-icon name="chatbubble-outline"></ion-icon></a>  
+	          <a class="btn btn-link" href="{{url_for('orchard.report')}}?url={{result[1]}}"  data-toggle="tooltip" title="{{gettext('Report this entry')}}"><ion-icon name="flag-outline"></ion-icon></a> 
+	          <button class="btn btn-link" data-toggle="tooltip" title="{{gettext('Share this entry')}}" onClick="copyToClipboard('{{result[8]}}', 'copy{{result[0]}}')" id="copy{{result[0]}}"><ion-icon name="share-outline"></ion-icon></button> 
+                </div>
+	      </div><!-- card heard: links -->
+
+	      <p class="card-text small"><a href="{{result[1]}}" class="card-link">{{result[1]}}</a></p><!-- explicit link-->
+	      <p class="card-text small" style="margin-top:-10px">
+              <br>{{result[3]|safe}}<!--snippet-->
+              {% if result[7] != None %}
+	        <button class="btn btn-link collapsed" data-bs-toggle="collapse" data-bs-target="#collapse{{result[0]}}" aria-expanded="false" aria-controls="collapse{{result[0]}}">
+	          <img src="{{ url_for('static', filename='note.png')}}" width='30px' />
+                </button>
+              {% endif %}
+              </p>
+              {% if result[7] != None %}<!-- note -->
+              <div class="collapse" id="collapse{{result[0]}}">
+                <p class="card-text small">
+	          {% for note in result[7] %}
+	            {{note}}<br>
+	          {% endfor %}
+	        </p>
+	      </div>
+	      {% endif %}<!-- note -->
+              <hr>
+	    </div><!-- div card-body -->
+	  </div><!-- div card mt-2 -->
+          {% endfor %}
+        {% endif %}
+      </div><!-- col -->
+    </div><!-- row -->
+</div><!-- container -->
 <script src="{{ url_for('static', filename='js/loading.js')}}"></script>
 <script>
 $(document).ready(function(){


### PR DESCRIPTION
This PR includes a lot of restructuring, meant to simplify the PeARS index. IDs linking database entries with numpy matrix rows are now included under the 'vector' attribute of the Urls model.

The PR also includes more minor changes:
- some styling of the admin database;
- direct indexing of URLs, without writing the information submitted by the user to a file first. NB: this very nearly means we could get rid of the *userdata* directory, but it is still needed to index pdfs, which are first (temporarily) downloaded and processed page-by-page;
- improved admin access to database entries: the admin can now make changes to a number of fields in the database entry, automatically triggering appropriate changes in the pod structure and matrix shapes.
