### PR TITLE
Minimalparts/urlsuggestions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,7 +16,7 @@ from flask_mail import Mail
 # Import SQLAlchemy and LoginManager
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-from flask_login import LoginManager, current_user, login_required
+from flask_login import LoginManager, current_user
 
 dir_path = dirname(realpath(__file__))
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -283,7 +283,10 @@ def load_user(user_id):
 
 class MyAdminIndexView(AdminIndexView):
     def is_accessible(self):
-        return current_user.is_admin # This does the trick rendering the view only if the user is admin
+        try:
+            return current_user.is_admin # This does the trick rendering the view only if the user is admin
+        except:
+            return False
 
 
 admin = Admin(app, name='PeARS DB', template_mode='bootstrap3', index_view=MyAdminIndexView())

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -283,8 +283,8 @@ def load_user(user_id):
 
 class MyAdminIndexView(AdminIndexView):
     def is_accessible(self):
-        if current_user.is_authenticated:
-            return current_user.is_admin # This does the trick rendering the view only if the user is admin
+        if current_user.is_authenticated and current_user.is_admin:
+            return True # This does the trick rendering the view only if the user is admin
         else:
             return abort(404)
 
@@ -467,7 +467,7 @@ admin.add_view(SuggestionsModelView(Suggestions, db.session))
 @app.errorhandler(404)
 def page_not_found(e):
     # note that we set the 404 status explicitly
-    flash("Page not found. Redirecting to search page.")
+    flash("404. Page not found. Please return to search page.")
     return render_template("404.html"), 404
 
 @app.route('/manifest.json')

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -256,7 +256,7 @@ if not app.config['LIVE_MATRIX']:
 #######
 
 from flask_admin.contrib.sqla import ModelView
-from app.api.models import Pods, Urls, User, Personalization
+from app.api.models import Pods, Urls, User, Personalization, Suggestions
 from app.api.controllers import return_pod_delete
 from app.utils_db import delete_url_representations, delete_pod_representations, \
         rm_from_npz, add_to_npz, create_pod_in_db, create_pod_npz_pos, rm_doc_from_pos, update_db_idvs_after_npz_delete
@@ -449,10 +449,17 @@ class PersonalizationModelView(ModelView):
     can_edit = True
     page_size = 50
 
+class SuggestionsModelView(ModelView):
+    list_template = 'admin/pears_list.html'
+    column_searchable_list = ['url', 'pod']
+    can_edit = True
+    page_size = 50
+
 admin.add_view(PodsModelView(Pods, db.session))
 admin.add_view(UrlsModelView(Urls, db.session))
 admin.add_view(UsersModelView(User, db.session))
 admin.add_view(PersonalizationModelView(Personalization, db.session))
+admin.add_view(SuggestionsModelView(Suggestions, db.session))
 
 @app.route('/manifest.json')
 def serve_manifest():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -266,7 +266,11 @@ from flask_admin.contrib.sqla.view import ModelView
 from flask_admin.model.template import EndpointLinkRowAction
 
 # Authentification
-login_manager = LoginManager()
+class MyLoginManager(LoginManager):
+    def unauthorized(self):
+        return abort(404)        
+
+login_manager = MyLoginManager()
 login_manager.login_view = 'auth.login'
 login_manager.init_app(app)
 
@@ -481,7 +485,7 @@ admin.add_view(SuggestionsModelView(Suggestions, db.session))
 @app.errorhandler(404)
 def page_not_found(e):
     # note that we set the 404 status explicitly
-    flash("404. Page not found. Please return to search page.")
+    flash("The page that you are trying to access doesn't exist or you don't have sufficient permissions to access it. If you're not logged in, log in and try accessing the page again. If you're sure the page exists and that you should have access to it, contact the administrators.")
     return render_template("404.html"), 404
 
 @app.route('/manifest.json')

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -257,7 +257,6 @@ if not app.config['LIVE_MATRIX']:
 
 from flask_admin.contrib.sqla import ModelView
 from app.api.models import Pods, Urls, User, Personalization, Suggestions
-from app.api.controllers import return_pod_delete
 from app.utils_db import delete_url_representations, delete_pod_representations, \
         rm_from_npz, add_to_npz, create_pod_in_db, create_pod_npz_pos, rm_doc_from_pos, update_db_idvs_after_npz_delete
 
@@ -420,7 +419,7 @@ class PodsModelView(ModelView):
             self.on_model_delete(model)
             print("DELETING",model.name)
             # Add your custom logic here and don't forget to commit any changes e.g.
-            print(return_pod_delete(model.name))
+            delete_pod_representations(model.name)
             self.session.commit()
         except Exception as ex:
             if not self.handle_view_exception(ex):

--- a/app/__init_for_pythonanywhere__.py
+++ b/app/__init_for_pythonanywhere__.py
@@ -251,16 +251,20 @@ if not app.config['LIVE_MATRIX']:
 #######
 
 from flask_admin.contrib.sqla import ModelView
-from app.api.models import Pods, Urls, Personalization
-from app.api.controllers import return_pod_delete
-from app.utils_db import delete_url_representations
+from app.api.models import Pods, Urls, User, Personalization, Suggestions
+from app.utils_db import delete_url_representations, delete_pod_representations, \
+        rm_from_npz, add_to_npz, create_pod_in_db, create_pod_npz_pos, rm_doc_from_pos, update_db_idvs_after_npz_delete
 
 from flask_admin import expose
 from flask_admin.contrib.sqla.view import ModelView
 from flask_admin.model.template import EndpointLinkRowAction
 
 # Authentification
-login_manager = LoginManager()
+class MyLoginManager(LoginManager):
+    def unauthorized(self):
+        return abort(404)        
+
+login_manager = MyLoginManager()
 login_manager.login_view = 'auth.login'
 login_manager.init_app(app)
 
@@ -289,9 +293,9 @@ admin = Admin(app, name='PeARS DB', template_mode='bootstrap3', index_view=MyAdm
 
 class UrlsModelView(ModelView):
     list_template = 'admin/pears_list.html'
-    column_exclude_list = ['vector','snippet']
-    column_searchable_list = ['url', 'title', 'doctype', 'notes', 'pod']
-    column_editable_list = ['notes']
+    column_hide_backrefs = False
+    column_list = ['url', 'title', 'pod', 'notes']
+    column_searchable_list = ['url', 'title', 'pod', 'notes']
     can_edit = True
     page_size = 100
     form_widget_args = {
@@ -299,12 +303,6 @@ class UrlsModelView(ModelView):
             'readonly': True
         },
         'url': {
-            'readonly': True
-        },
-        'pod': {
-            'readonly': True
-        },
-        'snippet': {
             'readonly': True
         },
         'date_created': {
@@ -326,14 +324,66 @@ class UrlsModelView(ModelView):
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 flash(gettext('Failed to delete record. %(error)s', error=str(ex)), 'error')
-
             self.session.rollback()
-
             return False
         else:
             self.after_model_delete(model)
 
         return True
+
+    def update_model(self, form, model):
+        """
+            Update model from form.
+        """
+        try:
+            # at this point model variable has the unmodified values
+            old_pod = model.pod
+            _, contributor = old_pod.split('.u.')
+            if '.u.' not in form.pod.data:
+                form.pod.data+='.u.'+contributor
+            new_pod = form.pod.data
+            new_theme = new_pod.split('.u.')[0]
+            p = db.session.query(Pods).filter_by(name=old_pod).first()
+            lang = p.language
+            form.populate_obj(model)
+
+            # at this point model variable has the form values
+            # your on_model_change is called
+            self._on_model_change(form, model, False)
+
+            # model is now being committed
+            self.session.commit()
+        except Exception as ex:
+            if not self.handle_view_exception(ex):
+                flash(gettext('Failed to update record. %(error)s', error=str(ex)), 'error')
+            self.session.rollback()
+            return False
+        else:
+            # model is now committed to the database
+            if old_pod != new_pod:
+                print(f"Pod name has changed from {old_pod} to {new_pod}!")
+                print("Move vector in npz file")
+                try:
+                    pod_path = create_pod_npz_pos(contributor, new_theme, lang)
+                    create_pod_in_db(contributor, new_theme, lang)
+                    idv, v = rm_from_npz(model.vector, old_pod)
+                    update_db_idvs_after_npz_delete(idv, old_pod)
+                    add_to_npz(v, pod_path+'.npz')
+                    #Removing from pos but not re-adding since current version does not make use of positional index. To fix.
+                    rm_doc_from_pos(model.id, old_pod)
+                    self.session.commit()
+                    #If pod empty, delete
+                    if len(db.session.query(Urls).filter_by(pod=old_pod).all()) == 0:
+                        delete_pod_representations(old_pod)
+
+                except Exception as ex:
+                    if not self.handle_view_exception(ex):
+                        flash(gettext('Failed to update record. %(error)s', error=str(ex)), 'error')
+                    self.session.rollback()
+                    return False
+            self.after_model_change(form, model, False)
+        return True
+
 
 class PodsModelView(ModelView):
     list_template = 'admin/pears_list.html'
@@ -362,7 +412,7 @@ class PodsModelView(ModelView):
             self.on_model_delete(model)
             print("DELETING",model.name)
             # Add your custom logic here and don't forget to commit any changes e.g.
-            print(return_pod_delete(model.name))
+            delete_pod_representations(model.name)
             self.session.commit()
         except Exception as ex:
             if not self.handle_view_exception(ex):
@@ -410,20 +460,25 @@ class PersonalizationModelView(ModelView):
     def is_accessible(self):
         return can_access_flaskadmin()
 
-
+class SuggestionsModelView(ModelView):
+    list_template = 'admin/pears_list.html'
+    column_searchable_list = ['url', 'pod']
+    can_edit = True
+    page_size = 50
+    def is_accessible(self):
+        return can_access_flaskadmin()
 
 admin.add_view(PodsModelView(Pods, db.session))
 admin.add_view(UrlsModelView(Urls, db.session))
 admin.add_view(UsersModelView(User, db.session))
 admin.add_view(PersonalizationModelView(Personalization, db.session))
+admin.add_view(SuggestionsModelView(Suggestions, db.session))
 
 @app.errorhandler(404)
 def page_not_found(e):
     # note that we set the 404 status explicitly
-    flash("404. Page not found. Please return to search page.")
+    flash("The page that you are trying to access doesn't exist or you don't have sufficient permissions to access it. If you're not logged in, log in and try accessing the page again. If you're sure the page exists and that you should have access to it, contact the administrators.")
     return render_template("404.html"), 404
-
-
 
 @app.route('/manifest.json')
 def serve_manifest():

--- a/app/__init_for_pythonanywhere__.py
+++ b/app/__init_for_pythonanywhere__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from os.path import join, dirname, realpath
 
 # Import flask and template operators
-from flask import Flask, flash, send_file, send_from_directory, request
+from flask import Flask, flash, send_file, send_from_directory, request, abort
 from flask_migrate import Migrate
 from flask_admin import Admin, AdminIndexView
 from flask_mail import Mail
@@ -275,7 +275,10 @@ def load_user(user_id):
 
 class MyAdminIndexView(AdminIndexView):
     def is_accessible(self):
-        return current_user.is_admin # This does the trick rendering the view only if the user is admin
+        if current_user.is_authenticated and current_user.is_admin:
+            return True # This does the trick rendering the view only if the user is admin
+        else:
+            return abort(404)
 
 
 admin = Admin(app, name='PeARS DB', template_mode='bootstrap3', index_view=MyAdminIndexView())
@@ -401,6 +404,12 @@ admin.add_view(PodsModelView(Pods, db.session))
 admin.add_view(UrlsModelView(Urls, db.session))
 admin.add_view(UsersModelView(User, db.session))
 admin.add_view(PersonalizationModelView(Personalization, db.session))
+
+@app.errorhandler(404)
+def page_not_found(e):
+    # note that we set the 404 status explicitly
+    flash("404. Page not found. Please return to search page.")
+    return render_template("404.html"), 404
 
 
 

--- a/app/api/controllers.py
+++ b/app/api/controllers.py
@@ -8,11 +8,10 @@ import numpy as np
 from os import remove, getenv
 from os.path import dirname, join, realpath, isfile
 from flask import Blueprint, jsonify, request, render_template, url_for
-from flask_login import login_required
 from scipy.sparse import vstack, save_npz, load_npz
 from app.forms import SearchForm
 from app.api.models import Urls, Pods
-from app.auth.decorators import check_is_confirmed
+from app.auth.decorators import check_permissions, check_is_confirmed
 from app import app, db, models
 from app.indexer.posix import load_posix, dump_posix
 from app.indexer.vectorizer import scale
@@ -72,8 +71,7 @@ def return_pod_delete(pod_name):
     delete_pod_representations(pod_name)
 
 @api.route('/urls/')
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True)
 def return_urls():
     return jsonify(json_list=[i.serialize for i in Urls.query.all()])
 

--- a/app/api/controllers.py
+++ b/app/api/controllers.py
@@ -49,27 +49,6 @@ def return_query_results():
     results = get_search_results(query)
     return jsonify(json_list=results)
 
-@api.route('/pods/')
-@login_required
-@check_is_confirmed
-def return_pods():
-    return jsonify(json_list=[p.serialize for p in Pods.query.all()])
-
-@api.route('/pods/<pod>/')
-@login_required
-@check_is_confirmed
-def return_pod(pod):
-    pod = pod.replace('+', ' ')
-    p = db.session.query(Pods).filter_by(name=pod).first()
-    return jsonify(p.serialize)
-
-@api.route('/pods/delete', methods=["GET","POST"])
-@login_required
-@check_is_confirmed
-def return_pod_delete(pod_name):
-    print("Unsubscribing pod...", pod_name)
-    delete_pod_representations(pod_name)
-
 @api.route('/urls/')
 @check_permissions(login=True, confirmed=True)
 def return_urls():
@@ -86,12 +65,3 @@ def return_specific_url():
     displayresults = prepare_gui_results("",{u:url})
     return render_template('search/results.html', query="", results=displayresults, \
             internal_message=internal_message, searchform=SearchForm())
-
-@api.route('/suggest/', methods=['POST'])
-def post_suggestion():
-    url = request.form.get('url')
-    theme = request.form.get('theme')
-    note = request.form.get('note')
-    contributor = 'anonymous'
-    create_suggestion_in_db(url=url, pod=theme, notes=note, contributor=contributor)
-    return "Thank you for your suggestion."

--- a/app/api/controllers.py
+++ b/app/api/controllers.py
@@ -18,7 +18,7 @@ from app.indexer.posix import load_posix, dump_posix
 from app.indexer.vectorizer import scale
 from app.search.controllers import get_search_results, prepare_gui_results
 from app.search.score_pages import mk_podsum_matrix
-from app.utils_db import delete_pod_representations
+from app.utils_db import delete_pod_representations, create_suggestion_in_db
 
 # Define the blueprint:
 api = Blueprint('api', __name__, url_prefix='/api')
@@ -77,7 +77,6 @@ def return_pod_delete(pod_name):
 def return_urls():
     return jsonify(json_list=[i.serialize for i in Urls.query.all()])
 
-
 @api.route('/get', methods=["GET"])
 def return_specific_url():
     internal_message = ""
@@ -90,4 +89,11 @@ def return_specific_url():
     return render_template('search/results.html', query="", results=displayresults, \
             internal_message=internal_message, searchform=SearchForm())
 
-
+@api.route('/suggest/', methods=['POST'])
+def post_suggestion():
+    url = request.form.get('url')
+    theme = request.form.get('theme')
+    note = request.form.get('note')
+    contributor = 'anonymous'
+    create_suggestion_in_db(url=url, pod=theme, notes=note, contributor=contributor)
+    return "Thank you for your suggestion."

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -41,6 +41,35 @@ class Base(db.Model):
         onupdate=db.func.current_timestamp())
 
 
+class Suggestions(Base):
+    id = db.Column(db.Integer, primary_key=True)
+    url = db.Column(db.String(1000))
+    pod = db.Column(db.String(1000))
+    notes = db.Column(db.String(1000))
+    contributor = db.Column(db.String(1000))
+
+    def __init__(self, url=None, pod=None, notes=None, contributor=None):
+        self.url = url
+        self.pod = pod
+        self.notes = notes
+        self.contributor = contributor
+
+    def __repr__(self):
+        return self.url
+
+    @property
+    def serialize(self):
+        return {
+            'id': self.id,
+            'pod': self.pod,
+            'notes': self.notes,
+            'contributor': self.contributor
+        }
+
+    def as_dict(self):
+        return {c.name: str(getattr(self, c.name)) for c in self.__table__.columns}
+
+
 class Urls(Base):
     id = db.Column(db.Integer, primary_key=True)
     url = db.Column(db.String(1000))

--- a/app/auth/controllers.py
+++ b/app/auth/controllers.py
@@ -13,6 +13,7 @@ from app import app, db
 from flask import (Blueprint, flash, request, render_template, Response, redirect, url_for)
 from flask_babel import gettext
 from datetime import datetime
+from app.auth.decorators import check_permissions
 from app.auth.token import send_email, send_reset_password_email, generate_token, confirm_token
 from app.auth.captcha import mk_captcha, check_captcha
 
@@ -22,7 +23,7 @@ auth = Blueprint('auth', __name__, url_prefix='/auth')
 ''' LOGGING OUT '''
 
 @auth.route('/logout')
-@login_required
+@check_permissions(login=True)
 def logout():
     logout_user()
     flash(gettext("You have successfully logged out."), "success")
@@ -123,7 +124,7 @@ def signup():
 
         login_user(new_user)
 
-        flash(gettext("A confirmation has been sent via email."), "success")
+        flash(gettext("Welcome! Your signup is almost complete; confirm your email address to fully activate your account."), "success")
         return redirect(url_for("auth.inactive"))
     else:
         print("FORM ERRORS:", form.errors)
@@ -134,7 +135,7 @@ def signup():
         return render_template('auth/signup.html', form=form, new_users_allowed=new_users_allowed)
 
 @auth.route("/registration-confirm/<token>")
-@login_required
+@check_permissions(login=True)
 def confirm_email(token):
     if current_user.is_confirmed:
         flash(gettext("Account already confirmed."), "success")
@@ -152,7 +153,7 @@ def confirm_email(token):
     return redirect(url_for("search.index"))
 
 @auth.route("/resend")
-@login_required
+@check_permissions(login=True)
 def resend_confirmation():
     if current_user.is_confirmed:
         flash(gettext("Your account has already been confirmed."), "success")
@@ -196,16 +197,21 @@ def password_reset(token):
         return redirect(url_for('search.index'))
     form = PasswordChangeForm(request.form)
     email = confirm_token(token)
-    user = User.query.filter_by(email=email).first_or_404()
-    if user.email == email:
-        login_user(user)
-        return render_template('auth/password_change.html', username=user.username, form=form)
+    if email is not None:
+        user = User.query.filter_by(email=email).first()
+        if user.email == email:
+            login_user(user)
+            return render_template('auth/password_change.html', username=user.username, form=form)
+        else:
+            flash(gettext("The confirmation link is invalid or has expired."), "danger")
+            return redirect(url_for("auth.password_forgotten"))
     else:
         flash(gettext("The confirmation link is invalid or has expired."), "danger")
         return redirect(url_for("auth.password_forgotten"))
 
+
 @auth.route("/password-change", methods=['GET', 'POST'])
-@login_required
+@check_permissions(login=True)
 def password_change():
     form = PasswordChangeForm(request.form)
     
@@ -224,7 +230,7 @@ def password_change():
 ''' INACTIVE '''
 
 @auth.route("/inactive")
-@login_required
+@check_permissions(login=True)
 def inactive():
     if current_user.is_confirmed:
         return redirect(url_for("search.index"))

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -3,8 +3,6 @@ from functools import wraps
 from flask import render_template, url_for, flash, current_app
 from flask_babel import gettext
 
-from . import VIEW_FUNCTIONS_PERMISSIONS
-
 
 def get_func_identifier(func):
     return func.__module__ + "." + func.__name__
@@ -32,13 +30,6 @@ def check_permissions(login=False, confirmed=False, admin=False):
 
             # otherwise: no login required, keep the function as is
             return new_func(*args, **kwargs)
-
-
-        VIEW_FUNCTIONS_PERMISSIONS[get_func_identifier(func)] = {
-            "login": login,
-            "confirmed": confirmed,
-            "admin": admin
-        }
 
         return decorated_function
 

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1,24 +1,76 @@
 from flask_login import current_user
 from functools import wraps
-from flask import redirect, url_for, flash
+from flask import render_template, url_for, flash, current_app
 from flask_babel import gettext
+
+from . import VIEW_FUNCTIONS_PERMISSIONS
+
+
+def get_func_identifier(func):
+    return func.__module__ + "." + func.__name__
+
+
+def check_permissions(login=False, confirmed=False, admin=False):
+    def decorator(func):    
+        @wraps(func)
+        def decorated_function(*args, **kwargs):
+
+            new_func = func
+
+            if admin:
+                # maximum security level: checks if we're logged in AND have admin rights
+                # (confirmation isn't checked since having been made admin implies having been granted permission)
+                new_func = check_is_admin(func)
+
+            elif confirmed:
+                # medium security level: checks if we're logged in AND confirmed
+                new_func = check_is_confirmed(func)
+
+            elif login:
+                # minimum security: only check if user is logged in: 
+                new_func = check_is_logged_in(func)
+
+            # otherwise: no login required, keep the function as is
+            return new_func(*args, **kwargs)
+
+
+        VIEW_FUNCTIONS_PERMISSIONS[get_func_identifier(func)] = {
+            "login": login,
+            "confirmed": confirmed,
+            "admin": admin
+        }
+
+        return decorated_function
+
+    return decorator
+
+# replaces the flask built-in login_required decorator
+def check_is_logged_in(func):
+    @wraps(func)
+    def decorated_function(*args, **kwargs):
+        if not current_user.is_authenticated:
+            return current_app.login_manager.unauthorized()
+        return func(*args, **kwargs)
+    return decorated_function
 
 def check_is_confirmed(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
+        if not current_user.is_authenticated:
+            return current_app.login_manager.unauthorized()        
         if current_user.is_confirmed is False:
-            flash(gettext("Please confirm your account!"), "warning")
-            return redirect(url_for("auth.inactive"))
+            flash(gettext("You are trying to access a page that requires your account to be verified."), "warning")
+            return render_template("auth/inactive.html"), 403
         return func(*args, **kwargs)
-
     return decorated_function
 
 def check_is_admin(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
+        if not current_user.is_authenticated:
+            return current_app.login_manager.unauthorized()
         if current_user.is_admin is False:
-            flash(gettext("The page you requested is admin only."), "warning")
-            return redirect(url_for("search.index"))
+            return current_app.login_manager.unauthorized()
         return func(*args, **kwargs)
 
     return decorated_function

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1,12 +1,24 @@
 from flask_login import current_user
 from functools import wraps
+from flask import redirect, url_for, flash
+from flask_babel import gettext
 
 def check_is_confirmed(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
         if current_user.is_confirmed is False:
             flash(gettext("Please confirm your account!"), "warning")
-            return redirect(url_for("accounts.inactive"))
+            return redirect(url_for("auth.inactive"))
+        return func(*args, **kwargs)
+
+    return decorated_function
+
+def check_is_admin(func):
+    @wraps(func)
+    def decorated_function(*args, **kwargs):
+        if current_user.is_admin is False:
+            flash(gettext("The page you requested is admin only."), "warning")
+            return redirect(url_for("search.index"))
         return func(*args, **kwargs)
 
     return decorated_function

--- a/app/auth/token.py
+++ b/app/auth/token.py
@@ -16,7 +16,7 @@ def confirm_token(token, expiration=3600):
         )
         return email
     except Exception:
-        return False
+        return None
 
 def send_email(to, subject, template):
     msg = Message(

--- a/app/cli/rebuild.py
+++ b/app/cli/rebuild.py
@@ -1,0 +1,102 @@
+# Scripts to rebuild a database and pods from backups
+from os.path import join
+import joblib
+from pathlib import Path
+import numpy as np
+import pandas as pd
+from scipy.sparse import vstack, load_npz, save_npz, csr_matrix
+from sqlalchemy import create_engine
+from app import db, VEC_SIZE
+from app.api.models import User, Personalization
+from app.utils_db import create_or_replace_url_in_db, create_pod_in_db, create_pod_npz_pos
+
+def rebuild_personalization(basedir):
+    source_db = 'sqlite:///' + join(basedir, 'app.db')
+    cnx = create_engine(source_db).connect()
+    df = pd.read_sql_table('personalization', cnx)
+    for _, f in df.iterrows():
+        feature = f['feature']
+        text = f['text']
+        language = f['language']
+        feature = Personalization(feature=feature, text=text, language=language)
+        db.session.add(feature)
+        db.session.commit()
+
+def rebuild_users(basedir):
+    source_db = 'sqlite:///' + join(basedir, 'app.db')
+    cnx = create_engine(source_db).connect()
+    df = pd.read_sql_table('user', cnx)
+    for _, u in df.iterrows():
+        print(u['username'])
+        username = u['username']
+        email = u['email']
+        is_admin = u['is_admin']
+        user = User(username=username, email=email, is_admin=is_admin)
+        try:
+            confirmed_on = u['confirmed_on']
+            password = u['password']
+            user.password = password
+            user.is_confirmed=True
+            user.confirmed_on=confirmed_on
+        except:
+            print("Issue with confirmation date of user", username)
+        db.session.add(user)
+        db.session.commit()
+
+def rebuild_pods_and_urls(pod_dir, basedir):
+    source_db = 'sqlite:///' + join(basedir, 'app.db')
+    source_pod_dir = join(basedir, 'pods')
+    cnx = create_engine(source_db).connect()
+    df = pd.read_sql_table('pods', cnx)
+    for _, p in df.iterrows():
+        print(f"\n\n POD {p['name']}")
+        dfu = pd.read_sql_table('urls', cnx)
+        urls = dfu.loc[dfu['pod'] == p['name']]
+        theme = p['name'].split('.u.')[0]
+        username = p['name'].split('.u.')[1]
+        lang = p['language']
+        try:
+            idx_path = join(source_pod_dir, username, username+'.idx')
+            idx_to_url = joblib.load(idx_path)
+            print(">> Shape idx to url:", len(idx_to_url))
+        except:
+            continue
+        
+        try:
+            npz_idx_path = join(source_pod_dir, username, lang, p['name']+'.npz.idx')
+            npz_to_idx = joblib.load(npz_idx_path)
+            print(">> Shape npz to idx:", len(idx_to_url))
+        except:
+            continue
+
+        try:
+            npz_path = join(source_pod_dir, username, lang, p['name']+'.npz')
+            npz = load_npz(npz_path).toarray()
+            print(">> Shape npz:", npz.shape)
+        except:
+            continue
+
+        user_dir = join(pod_dir, username, lang)
+        Path(user_dir).mkdir(parents=True, exist_ok=True)
+        create_pod_in_db(username, theme, lang)
+        new_npz_path = join(pod_dir, username, lang, p['name']+'.npz')
+        m = np.zeros((1,VEC_SIZE))
+        m = csr_matrix(m)
+        
+        for _, url in urls.iterrows():
+            try:
+                k = idx_to_url[1].index(url['url'])
+                idx = idx_to_url[0][k]
+                k = npz_to_idx[1].index(idx)
+                row = npz_to_idx[0][k]
+                v = npz[row]
+                m = vstack((m,v))
+                vector = m.shape[0]-1
+                notes = ''
+                if url['notes']:
+                    notes = url['notes']
+                create_or_replace_url_in_db(url['url'], url['title'], vector, url['snippet'], theme, lang, notes, url['share'], url['contributor'], url['doctype'])
+            except:
+                    print(">> CLI:REBUILD DB: Problem with url",url['url'])
+        save_npz(new_npz_path, m)
+

--- a/app/forms.py
+++ b/app/forms.py
@@ -34,8 +34,16 @@ class UsernameChangeForm(FlaskForm):
 
 class IndexerForm(FlaskForm):
     suggested_url = URLField(lazy_gettext('The url to index'), [DataRequired(), URL()], render_kw={"placeholder": lazy_gettext("The URL you would like to index.")})
-    theme = StringField(lazy_gettext('Theme'), [DataRequired(), Length(max=50)],  render_kw={"placeholder": lazy_gettext("A category for your URL. Start typing and suggestions will appear, but you can also write your own.")})
+    theme = StringField(lazy_gettext('Category'), [DataRequired(), Length(max=50)],  render_kw={"placeholder": lazy_gettext("A category for your URL. Start typing and suggestions will appear, but you can also write your own.")})
     note = StringField(lazy_gettext('Optional note*'), [Length(max=100)],  render_kw={"placeholder": lazy_gettext("Anything extra you would like people to know about this resource.")})
+    accept_tos = BooleanField(lazy_gettext('I confirm that my suggestion does not contravene the Terms of Service'), [DataRequired()])
+
+class SuggestionForm(FlaskForm):
+    suggested_url = URLField(lazy_gettext('Suggested url.'), [DataRequired(), URL()], render_kw={"placeholder": lazy_gettext("The URL you would like to suggest.")})
+    theme = StringField(lazy_gettext('Category'), [DataRequired(), Length(max=50)],  render_kw={"placeholder": lazy_gettext("A category for your URL. Start typing and suggestions will appear, but you can also write your own.")})
+    note = StringField(lazy_gettext('Optional note*'), [Length(max=100)],  render_kw={"placeholder": lazy_gettext("Anything extra you would like people to know about this resource.")})
+    captcha = HiddenField()
+    captcha_answer = StringField('', [DataRequired()],  render_kw={"placeholder": lazy_gettext("Write your answer to the captcha.")})
     accept_tos = BooleanField(lazy_gettext('I confirm that my suggestion does not contravene the Terms of Service'), [DataRequired()])
 
 class ManualEntryForm(FlaskForm):

--- a/app/indexer/controllers.py
+++ b/app/indexer/controllers.py
@@ -12,7 +12,7 @@ from flask_login import login_required, current_user
 from flask_babel import gettext
 from langdetect import detect
 from app.auth.captcha import mk_captcha, check_captcha
-from app.auth.decorators import check_is_confirmed, check_is_admin
+from app.auth.decorators import check_permissions
 from app import app, db
 from app.api.models import Urls, Pods
 from app.indexer import mk_page_vector
@@ -29,9 +29,7 @@ indexer = Blueprint('indexer', __name__, url_prefix='/indexer')
 
 
 @indexer.route("/", methods=["GET"])
-@login_required
-@check_is_confirmed
-@check_is_admin
+@check_permissions(login=True, confirmed=True, admin=True)
 def index():
     """Displays the indexer page.
     Computes and returns the total number
@@ -60,11 +58,8 @@ def suggest():
     themes = list(set([p.name.split('.u.')[0] for p in pods]))
     return render_template("indexer/suggest.html", form=form, themes=themes)
 
-
 @indexer.route("/amend", methods=["GET"])
-@login_required
-@check_is_confirmed
-@check_is_admin
+@check_permissions(login=True, confirmed=True, admin=True)
 def correct_entry():
     """Redisplays the indexer page when the
     user wishes to change their entry.
@@ -96,9 +91,7 @@ def correct_entry():
             num_entries=num_db_entries, form1=form1, form2=form2, themes=themes, default_screen=default_screen)
 
 @indexer.route("/url", methods=["POST"])
-@login_required
-@check_is_confirmed
-@check_is_admin
+@check_permissions(login=True, confirmed=True, admin=True)
 def index_from_url():
     """ Route for URL entry form.
     This is to index a URL that the user
@@ -131,9 +124,7 @@ def index_from_url():
 
 
 @indexer.route("/manual", methods=["POST"])
-@login_required
-@check_is_confirmed
-@check_is_admin
+@check_permissions(login=True, confirmed=True, admin=True)
 def index_from_manual():
     """ Route for manual (offline) entry form.
     This is to index offline tips that the user

--- a/app/orchard/controllers.py
+++ b/app/orchard/controllers.py
@@ -4,14 +4,14 @@
 
 # Import flask dependencies
 from flask import Blueprint, request, render_template, send_from_directory, flash, redirect, url_for
-from flask_login import login_required, current_user
+from flask_login import current_user
 from flask_babel import gettext
 from os.path import dirname, realpath, join
 from app.api.models import Urls, Pods
 from app.utils_db import mv_pod
 from app import app, db
 from app.orchard.mk_urls_file import get_url_list_for_users
-from app.auth.decorators import check_is_confirmed
+from app.auth.decorators import check_permissions
 from app.auth.token import send_email
 from app.forms import ReportingForm, AnnotationForm, FeedbackForm
 
@@ -53,8 +53,7 @@ def get_a_pod():
     return render_template('orchard/get-a-pod.html', urls=urls, query=query, location=filename)
 
 @orchard.route("/download", methods=['GET'])
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True, admin=True)
 def download_file():
     filename = request.args.get('filename')
     print('>> orchard: download_file:',filename)
@@ -62,8 +61,7 @@ def download_file():
 
 
 @orchard.route("/rename", methods=['GET'])
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True, admin=True)
 def rename_pod():
     podname = request.args.get('oldname')
     newname = request.args.get('newname')
@@ -74,8 +72,7 @@ def rename_pod():
 
 
 @orchard.route("/report", methods=['GET','POST'])
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True)
 def report():
     username = current_user.username
     email = current_user.email
@@ -95,8 +92,7 @@ def report():
 
 
 @orchard.route("/feedback", methods=['GET','POST'])
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True)
 def feedback():
     username = current_user.username
     email = current_user.email
@@ -113,8 +109,7 @@ def feedback():
 
 
 @orchard.route("/annotate", methods=['GET','POST'])
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True)
 def annotate():
     username = current_user.username
     form = AnnotationForm()

--- a/app/orchard/controllers.py
+++ b/app/orchard/controllers.py
@@ -22,8 +22,6 @@ orchard = Blueprint('orchard', __name__, url_prefix='/orchard')
 
 @orchard.route('/')
 @orchard.route('/index', methods=['GET', 'POST'])
-@login_required
-@check_is_confirmed
 def index():
     #query = db.session.query(Urls.pod.distinct().label("pod"))
     #keywords = [row.pod for row in query.all()]
@@ -48,8 +46,6 @@ def index():
 
 
 @orchard.route('/get-a-pod', methods=['POST', 'GET'])
-@login_required
-@check_is_confirmed
 def get_a_pod():
     query = request.args.get('pod')
     filename, urls = get_url_list_for_users(query)

--- a/app/settings/controllers.py
+++ b/app/settings/controllers.py
@@ -9,13 +9,13 @@ from glob import glob
 from os import rename, getenv
 from os.path import dirname, realpath, join, isdir, exists
 from flask import Blueprint, flash, request, render_template, redirect, url_for, session
-from flask_login import login_required, current_user, logout_user
+from flask_login import current_user, logout_user
 from flask_babel import gettext
 from app import app, db
 from app.api.models import Urls, User
 from app.forms import EmailChangeForm, UsernameChangeForm
 from app.utils_db import delete_url_representations
-from app.auth.decorators import check_is_confirmed
+from app.auth.decorators import check_permissions
 from app.auth.token import send_email
 
 
@@ -29,7 +29,7 @@ pod_dir = getenv("PODS_DIR", join(dir_path,'pods'))
 
 # Set the route and accepted methods
 @settings.route("/")
-@login_required
+@check_permissions(login=True)
 def index():
     username = current_user.username
     email = current_user.email
@@ -69,8 +69,7 @@ def toggle_theme():
 
 
 @settings.route('/delete', methods=['GET'])
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True, admin=True)
 def delete_url():
     username = current_user.username
     url = request.args.get('url').split('get?url=')[1]
@@ -88,8 +87,7 @@ def delete_url():
     return redirect(url_for("settings.index"))
 
 @settings.route('/delcomment', methods=['GET'])
-@login_required
-@check_is_confirmed
+@check_permissions(login=True, confirmed=True)
 def delete_comment():
     username = current_user.username
     u = request.args.get('url').split('get?url=')[1]
@@ -147,7 +145,7 @@ def username_exists(username):
 
 
 @settings.route('/delete_account', methods=['GET'])
-@login_required
+@check_permissions(login=True)
 def delete_account():
     username = current_user.username
     users = db.session.query(User).all()
@@ -168,7 +166,7 @@ def delete_account():
 
 
 @settings.route('/change_email', methods=['POST'])
-@login_required
+@check_permissions(login=True)
 def change_email():
     form = EmailChangeForm(request.form)
     if form.validate_on_submit():
@@ -187,7 +185,7 @@ def change_email():
 
 
 @settings.route('/change_username', methods=['POST'])
-@login_required
+@check_permissions(login=True)
 def change_username():
     username = current_user.username
     form = UsernameChangeForm(request.form)

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,0 +1,46 @@
+<!--
+SPDX-FileCopyrightText: 2022 PeARS Project, <community@pearsproject.org>, 
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+{% extends "base/base.html" %}
+{% from "base/_formhelpers.html" import render_search_field %}
+{% block body %}
+  <div class="row">
+    <div class="col-lg-2"></div>
+    <div class="col-lg-8 text-center mt-5">
+      {% if own_brand %}
+	{% if session.get('theme') == 'dark' %}
+          <a href="{{ url_for('search.index')}}"><img width=350px; src="{{url_for('serve_logos', path='logo-dark.png')}}"></a>
+	{% else %}
+          <a href="{{ url_for('search.index')}}"><img width=350px; src="{{url_for('serve_logos', path='logo.png')}}"></a>
+	{% endif %}
+      {% else %}
+	{% if session.get('theme') == 'dark' %}
+          <a href="{{ url_for('search.index')}}"><img width=350px; src="{{ url_for('static', filename='pears-logo-dark.png')}}"></a>
+	{% else %}
+          <a href="{{ url_for('search.index')}}"><img width=350px; src="{{ url_for('static', filename='pears-logo.png')}}"></a>
+	{% endif %}
+      {% endif %}
+	{% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="notification is-danger">
+		    <br><b>{{ messages[0] }}</b>
+            </div>
+        {% endif %}
+        {% endwith %}
+    </div>
+  </div> 
+  {% if internal_message %}
+  <div class="row">
+    <div class="col-lg-8 mt-5 mx-auto">
+      <div class="alert alert-info alert-dismissible">
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        {{internal_message}}
+      </div>
+    </div>
+  </div>
+      {% endif %}
+{% endblock %}
+

--- a/app/templates/admin/index.html
+++ b/app/templates/admin/index.html
@@ -15,6 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		  <a href="{{url_for('urls.index_view')}}" class="btn btn-success btn-block">{{gettext('URLs')}}</a>
 		  <a href="{{url_for('pods.index_view')}}" class="btn btn-success btn-block">{{gettext('Pods')}}</a>
 		  <a href="{{url_for('user.index_view')}}" class="btn btn-success btn-block">{{gettext('Users')}}</a>
+		  <a href="{{url_for('suggestions.index_view')}}" class="btn btn-success btn-block">{{gettext('Suggestions')}}</a>
 		  <a href="{{url_for('personalization.index_view')}}" class="btn btn-success btn-block">{{gettext('Personalization')}}</a>
       </div>
     </div>

--- a/app/templates/auth/inactive.html
+++ b/app/templates/auth/inactive.html
@@ -3,7 +3,7 @@
 {% block body %}
 
 <div class="text-center">
-	<h1>{{gettext("Welcome!")}}</h1>
+	<h2>{{gettext("Account activation")}}</h2>
 	{% with messages = get_flashed_messages() %}
         {% if messages %}
             <div class="notification is-danger">
@@ -13,7 +13,7 @@
         {% endwith %}
   <br />
   <p>
-  {{gettext("You have not confirmed your account. Please check your inbox (and your spam folder) - you should have received an email with a confirmation link.")}}
+  {{gettext("Please check your inbox (and your spam folder) - you should have received an email with a confirmation link.")}}
   </p>
   <p>
   {{gettext("Didn't get the email?")}}

--- a/app/templates/base/base.html
+++ b/app/templates/base/base.html
@@ -66,12 +66,11 @@ SPDX-License-Identifier: AGPL-3.0-only
                     <hr class="d-lg-none text-white-50">
                 </li>
                 <li class="nav-item"><a class="nav-link" href="{{url_for('search.index')}}">{{gettext('Search')}}</a></li>
-		{% if current_user.is_authenticated and current_user.is_confirmed %}
+                <li class="nav-item"><a class="nav-link" href="{{url_for('indexer.suggest')}}">{{gettext('Suggest')}}</a></li>
+		{% if current_user.is_authenticated and current_user.is_confirmed and current_user.is_admin %}
                 <li class="nav-item"><a class="nav-link" href="{{url_for('indexer.index')}}">{{gettext('Index')}}</a></li>
 		{% endif %}
-		{% if current_user.is_authenticated and current_user.is_confirmed %}
-                <li class="nav-item"><a class="nav-link" href="{{url_for('orchard.index')}}">{{gettext('Themes')}}</a></li>
-		{% endif %}
+                <li class="nav-item"><a class="nav-link" href="{{url_for('orchard.index')}}">{{gettext('Categories')}}</a></li>
 		{% if current_user.is_authenticated and current_user.is_confirmed and current_user.is_admin %}
                 <li class="nav-item"><a class="nav-link" href="{{url_for('admin.index')}}">{{gettext('DB Admin')}}</a></li>          
 		{% endif %}

--- a/app/templates/indexer/suggest.html
+++ b/app/templates/indexer/suggest.html
@@ -1,0 +1,60 @@
+<!--
+SPDX-FileCopyrightText: 2024 PeARS Project, <community@pearsproject.org>, 
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+{% extends "base/base.html" %}
+{% from "base/_formhelpers.html" import render_field %}
+{% from "base/_formhelpers.html" import render_autocomplete_field %}
+{% block body %}
+<div class="container">
+  <div class="row p-3" style="display:block;">
+    <div class="card-group">
+      <div class="card indexer">
+        <div class="card-header text-center"><b>{{gettext("Suggest a URL to index")}}</b></div>
+        <div class="card-body">
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="notification is-danger">
+		 {% if session.get('theme') == 'dark' %}
+		 <div class="d-flex justify-content-start"><img src="{{ url_for('static', filename='happy_pears_dark.png')}}" width="30px"><h5>{{gettext(messages[0])}}</h5></div>
+		 {% else %}
+		 <div class="d-flex justify-content-start"><img src="{{ url_for('static', filename='happy_pears.png')}}" width="30px"><h5>{{gettext(messages[0])}}</h5></div>
+		 {% endif %}
+            </div>
+        {% endif %}
+        {% endwith %}
+	<form method="POST" accept-charset="UTF-8" action="{{url_for('indexer.run_suggest_url')}}" enctype="multipart/form-data" autocomplete="off">
+	<datalist id="themes"></datalist>
+        {{ form.hidden_tag() }}
+        <p>{{ render_field(form.suggested_url) }}</p>
+        <p>{{ render_autocomplete_field(form.theme) }}</p>
+        <p>{{ render_field(form.note) }}</p>
+	<p>{{ render_field(form.captcha_answer) }}</p>
+        <div class="form-check">
+          {{ form.accept_tos(class_="form-check-input") }}
+          <label class="form-check-label" for="legal">{{gettext("I confirm that my entry does not contravene the <a href='../terms-of-service'>terms of service</a> of this site.")}}</label>
+        </div>
+      </div><!-- card body -->
+      <div class="card-footer clearfix">
+        <span class="input-group-btn">
+                <input id="submit_button" type="submit" class="btn btn-success" value="{{gettext('Suggest')}}">
+      </div><!-- card footer -->
+    </form>
+    </div>
+   </div>
+  </div>
+
+</div><!-- /.container -->
+
+
+<script>
+  let themes = {{themes|tojson}};
+  let str = '';
+  for (theme of themes) {
+    str += '<option value="' + theme + '" />';
+  }
+  document.getElementById("themes").innerHTML = str;
+</script>
+{% endblock %}

--- a/app/templates/orchard/get-a-pod.html
+++ b/app/templates/orchard/get-a-pod.html
@@ -11,7 +11,9 @@ SPDX-License-Identifier: AGPL-3.0-only
     <div class="card">
 	    <div class="card-header"><b>{{gettext('Theme')}}: {{query}}</b></div>
          <div class="card-body">
+	     {% if current_user.is_authenticated and current_user.is_confirmed and current_user.is_admin %}
 		 <a href={{url_for('orchard.download_file', filename=location)}} target='_blank' class="btn btn-success" role="button">{{gettext('Download')}}</a><hr>
+	     {% endif %}
 	 {% for url in urls %}
 	 <a href='{{url}}'>{{url}}</a>
 	 <br>

--- a/app/templates/orchard/index.html
+++ b/app/templates/orchard/index.html
@@ -24,7 +24,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 	          <p class="card-text">{{p[1]}} {{gettext("entries")}}.</p>
 		  <a href="{{url_for('orchard.get_a_pod')}}?pod={{p[0]}}" class="btn btn-success">{{gettext("View")}}</a>
 		  {% if p[0] != 'Tips' %}
+		  {% if current_user.is_authenticated and current_user.is_confirmed and current_user.is_admin %}
 	          <button class="btn btn-link collapsed" data-bs-toggle="collapse" data-bs-target="#collapse{{p[2]}}" aria-expanded="false" aria-controls="collapse{{p[2]}}"><ion-icon name="pencil-outline"></ion-icon></button>
+		  {% endif %}
 		  {% endif %}
               </div>
             <div class="card card-body">

--- a/app/utils_db.py
+++ b/app/utils_db.py
@@ -12,7 +12,7 @@ from sqlalchemy import update
 import numpy as np
 from scipy.sparse import csr_matrix, load_npz, vstack, save_npz
 from app import db, models, VEC_SIZE
-from app.api.models import Urls, Pods
+from app.api.models import Urls, Pods, Suggestions
 from app.indexer.posix import load_posix, dump_posix
 
 dir_path = dirname(dirname(realpath(__file__)))
@@ -67,6 +67,12 @@ def create_pod_in_db(contributor, theme, lang):
         p.registered = True
         db.session.add(p)
         db.session.commit()
+
+def create_suggestion_in_db(url, pod, notes, contributor):
+    '''Add suggestion to database'''
+    s = Suggestions(url=url, pod=pod, notes=notes, contributor=contributor)
+    db.session.add(s)
+    db.session.commit()
 
 def create_or_replace_url_in_db(url, title, idv, snippet, theme, lang, note, share, contributor, entry_type):
     """Add a new URL to the database or update it.


### PR DESCRIPTION
Allowing any registered user to directly index urls is perhaps not greatly secure. Changed things so that only admins can index. But there is a new page allowing anybody (including unregistered visitors) to suggest urls to be indexed. This page has a little captcha associated with it. Suggestions are stored in a separate part of the database until an admin looks at them. Registered users retain additional rights, like commenting on urls.

Made categories (themes) visible to all users, so that people get an idea of what is included in the instance. But download and pod renaming can only be done by admins.

Also added CLI functions to rebuild the database from a backup. Flask Migrate was being too annoying.