### PR TITLE
20 max length of notes

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -35,32 +35,32 @@ class UsernameChangeForm(FlaskForm):
 class IndexerForm(FlaskForm):
     suggested_url = URLField(lazy_gettext('The url to index'), [DataRequired(), URL()], render_kw={"placeholder": lazy_gettext("The URL you would like to index.")})
     theme = StringField(lazy_gettext('Category'), [DataRequired(), Length(max=50)],  render_kw={"placeholder": lazy_gettext("A category for your URL. Start typing and suggestions will appear, but you can also write your own.")})
-    note = StringField(lazy_gettext('Optional note*'), [Length(max=100)],  render_kw={"placeholder": lazy_gettext("Anything extra you would like people to know about this resource.")})
+    note = StringField(lazy_gettext('Optional note*'), [Length(max=1000)],  render_kw={"placeholder": lazy_gettext("Anything extra you would like people to know about this resource. (Max 1000 characters.)")})
     accept_tos = BooleanField(lazy_gettext('I confirm that my suggestion does not contravene the Terms of Service'), [DataRequired()])
 
 class SuggestionForm(FlaskForm):
     suggested_url = URLField(lazy_gettext('Suggested url.'), [DataRequired(), URL()], render_kw={"placeholder": lazy_gettext("The URL you would like to suggest.")})
     theme = StringField(lazy_gettext('Category'), [DataRequired(), Length(max=50)],  render_kw={"placeholder": lazy_gettext("A category for your URL. Start typing and suggestions will appear, but you can also write your own.")})
-    note = StringField(lazy_gettext('Optional note*'), [Length(max=100)],  render_kw={"placeholder": lazy_gettext("Anything extra you would like people to know about this resource.")})
+    note = StringField(lazy_gettext('Optional note*'), [Length(max=1000)],  render_kw={"placeholder": lazy_gettext("Anything extra you would like people to know about this resource. (Max 1000 characters.)")})
     captcha_id = HiddenField()
     captcha_answer = StringField(lazy_gettext("Captcha: write down the characters you see in the image below (only lower-case letters, no numbers)."), [DataRequired()])
     accept_tos = BooleanField(lazy_gettext('I confirm that my suggestion does not contravene the Terms of Service'), [DataRequired()])
 
 class ManualEntryForm(FlaskForm):
     title = StringField(lazy_gettext('A title for your entry'), [DataRequired(), Length(min=8, max=100, message=lazy_gettext("The title of your entry should have between 4 and 100 characters."))])
-    description = TextAreaField(lazy_gettext('Description'), [DataRequired(), Length(max=500)])
+    description = TextAreaField(lazy_gettext('Description'), [DataRequired(), Length(max=1000)],  render_kw={"placeholder": lazy_gettext("Anything extra you would like people to know about this resource. (Max 1000 characters.)")})
     accept_tos = BooleanField(lazy_gettext('I confirm that my entry does not contravene the Terms of Service'), [DataRequired()])
 
 class ReportingForm(FlaskForm):
     url = StringField(lazy_gettext('The url you are reporting'), [DataRequired(), URL()])
-    report = TextAreaField(lazy_gettext('Description of the issue'), [DataRequired(), Length(max=300)])
+    report = TextAreaField(lazy_gettext('Description of the issue'), [DataRequired(), Length(max=1000)],  render_kw={"placeholder": lazy_gettext("Max 1000 characters.")})
     accept_tos = BooleanField(lazy_gettext('I confirm that I may be contacted in relation to my report.'), [DataRequired()])
 
 class FeedbackForm(FlaskForm):
-    report = TextAreaField(lazy_gettext('Your feedback'), [DataRequired(), Length(max=1000)])
+    report = TextAreaField(lazy_gettext('Your feedback'), [DataRequired(), Length(max=1000)],  render_kw={"placeholder": lazy_gettext("Max 1000 characters.")})
     accept_tos = BooleanField(lazy_gettext('I confirm that I may be contacted in relation to my report.'), [DataRequired()])
 
 class AnnotationForm(FlaskForm):
     url = StringField(lazy_gettext('The url you wish to annotate'), [DataRequired(), URL()])
-    note = TextAreaField(lazy_gettext('Your note'), [DataRequired(), Length(max=300)])
+    note = TextAreaField(lazy_gettext('Your note (max 1000 characters)'), [DataRequired(), Length(max=1000)])
     accept_tos = BooleanField(lazy_gettext('I confirm that my comment can be openly published.'), [DataRequired()])

--- a/app/templates/base/_formhelpers.html
+++ b/app/templates/base/_formhelpers.html
@@ -54,7 +54,7 @@
 {% endmacro %}
 
 {% macro render_password_field(field) %}
-<div class="form-group">template
+<div class="form-group">
 	{{ field.label }} <a class="small" href={{url_for('auth.password_forgotten')}}>{{gettext('Password forgotten?')}}</a> 
         {{ field(class_="form-control input-s", size=32) }}
 </div>


### PR DESCRIPTION
This fixes issue #20 by making the length of notes consistent across all forms. 
Also fixed 'typo' in login template.