### PR TITLE
Update GHA to  build ARM based image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,13 +37,19 @@ jobs:
           BRANCH_NAME=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///')
           echo "::set-output name=tag::${BRANCH_NAME}"
         fi
-
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+  
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
         context: .
         file: deployment/Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: pearsproject/pears-federated:${{ steps.docker-tag.outputs.tag }}
 
     - name: Image digest


### PR DESCRIPTION
With this PR we now build ARM images as well. Unfortunately build time becomes a bit longer, but for now we can live with that
![image](https://github.com/user-attachments/assets/fec56492-2afd-42e3-b60f-ff998a4b2fb6)
