### PR TITLE
Move remote instance loading to background thread to fix slow startup

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -183,8 +183,27 @@ if not app.config['LIVE_MATRIX']:
 
 from app.search.cross_instance_search import filter_instances_by_language
 from flask import url_for
+import threading
+import numpy as np
 
-instances, M, _  = filter_instances_by_language()
+# Initialize with empty values so the app can serve requests immediately.
+# A background thread will populate these once the remote instances respond.
+instances = []
+M = np.array([])
+
+def _load_remote_instances():
+    global instances, M
+    try:
+        instances, M, skipped = filter_instances_by_language()
+        if skipped:
+            for s in skipped:
+                logging.warning(f"Skipped remote instance {s['instance']}: {s['reason']}")
+        logging.info(f"Loaded {len(instances)} remote instance(s) in background.")
+    except Exception as e:
+        logging.error(f"Failed to load remote instances: {e}")
+
+_instance_loader = threading.Thread(target=_load_remote_instances, daemon=True)
+_instance_loader.start()
 
 _sitename_check_completed = False
 @app.before_request

--- a/app/__init_for_pythonanywhere__.py
+++ b/app/__init_for_pythonanywhere__.py
@@ -183,8 +183,27 @@ if not app.config['LIVE_MATRIX']:
 
 from app.search.cross_instance_search import filter_instances_by_language
 from flask import url_for
+import threading
+import numpy as np
 
-instances, M, _  = filter_instances_by_language()
+# Initialize with empty values so the app can serve requests immediately.
+# A background thread will populate these once the remote instances respond.
+instances = []
+M = np.array([])
+
+def _load_remote_instances():
+    global instances, M
+    try:
+        instances, M, skipped = filter_instances_by_language()
+        if skipped:
+            for s in skipped:
+                logging.warning(f"Skipped remote instance {s['instance']}: {s['reason']}")
+        logging.info(f"Loaded {len(instances)} remote instance(s) in background.")
+    except Exception as e:
+        logging.error(f"Failed to load remote instances: {e}")
+
+_instance_loader = threading.Thread(target=_load_remote_instances, daemon=True)
+_instance_loader.start()
 
 _sitename_check_completed = False
 @app.before_request


### PR DESCRIPTION
## Summary

  - `filter_instances_by_language()` was called synchronously at module import time in `__init__.py`, blocking the app for ~90s while it contacts all known remote instances (9 instances,
  up to 3 HTTP requests each with 30s timeouts)
  - Moved the call to a background daemon thread so the app starts serving immediately (~2s)
  - Local search works right away; cross-instance results become available once the thread completes
  - Applied the same fix to `__init_for_pythonanywhere__.py`
