### PR TITLE
Update minimum dependency versions and fix startup warnings

### DIFF
--- a/app/indexer/access.py
+++ b/app/indexer/access.py
@@ -23,7 +23,7 @@ def robotcheck(url):
             elif l == 'Disallow: /' and parse is True:
                 disallowed.append(domain)
             elif 'Disallow:' in l and parse is True:
-                m = re.search('Disallow:\s*(.+)',l)
+                m = re.search(r'Disallow:\s*(.+)',l)
                 if m:
                     u = m.group(1)
                     if u[0] == '/':

--- a/app/utils.py
+++ b/app/utils.py
@@ -191,7 +191,7 @@ def parse_query(query):
     lang = None
     doctype = None
     clean_query = ""
-    m = re.search('(.*) -(..\s*)$',query)
+    m = re.search(r'(.*) -(..\s*)$',query)
     if m:
         query = m.group(1)
         lang = m.group(2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ blinker>=1.9.0
 bs4>=0.0.2
 certifi>=2026.2.25
 cffi>=2.0.0
-chardet>=7.1.0
 charset-normalizer>=3.4.6
 click>=8.3.1
 cryptography>=46.0.5


### PR DESCRIPTION
  ## Summary

  - Bump all minimum versions in requirements.txt to the latest releases (all tested and working)
  - Add lxml_html_clean>=0.4.4 as an explicit dependency (required by lxml 6.x, was missing)
  - Pin Flask-Admin>=1.6.1,<2.0 to avoid breaking change (2.0 upgrade will be handled separately)
  - Fix SyntaxWarning: invalid escape sequence '\s' in access.py and utils.py by using raw strings for regex patterns (triggered on Python 3.12+)
  - Remove chardet from requirements — not used by the project, and its presence triggered a RequestsDependencyWarning version mismatch in requests

  ## Notes

  - astroid 4.1.1 exists but is blocked by pylint 4.0.5 which caps astroid<4.1 — kept at 4.0.4
  - No other code changes needed — the app was already running on these versions since requirements.txt used >= minimums
  - The only remaining runtime warning (leaked semaphore in multiprocessing resource tracker) is a Python/OS-level issue outside the project's control