### PR TITLE
[dockerfile] Upgrade python version in dockerfile

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
This was causing the docker builds to fail since the latest versions in requirements.txt would requite python3.10 or higher