### PR TITLE
Log out user after account deletion to update navbar state

### DIFF
--- a/app/settings/controllers.py
+++ b/app/settings/controllers.py
@@ -214,6 +214,7 @@ def delete_account():
     print(">> DELETING ACCOUNT",username)
     current_user.remove()
     db.session.commit()
+    logout_user()
     flash(gettext("Your account has successfully been deleted."), "success")
     return redirect(url_for("search.index"))
 


### PR DESCRIPTION
  - Call logout_user() after account deletion so the session is cleared before redirecting to the index page
  - The navbar now correctly shows the logged-out state immediately after deletion

  Fixes #19