### PR TITLE
Handle invalid email in password forgotten form

### DIFF
--- a/app/auth/controllers.py
+++ b/app/auth/controllers.py
@@ -184,9 +184,12 @@ def password_forgotten():
     form = PasswordForgottenForm(request.form)
     
     if form.validate_on_submit():
-        # code to validate and add user to database goes here
         email = request.form.get('email')
-        user = User.query.filter_by(email=email).first() # if this returns a user, then the email exists in database
+        user = User.query.filter_by(email=email).first()
+
+        if not user:
+            flash(gettext("No account found with that email address."), "danger")
+            return redirect(url_for('auth.password_forgotten'))
 
         # generate confirmation email
         token = generate_token(user.email)


### PR DESCRIPTION
  - Check if the email exists in the database before attempting to generate a password reset token
  - If no account is found, flash an error message and redirect back to the password forgotten page instead of crashing

  Fixes #37