### PR TITLE
Fix Bengali language code: nb → bn

### DIFF
--- a/app/ling/language_codes.txt
+++ b/app/ling/language_codes.txt
@@ -4,7 +4,7 @@ fr;French
 ml;Malayalam
 da;Danish
 ar;Arabic
-nb;Bengali
+bn;Bengali
 eu;Basque
 ca;Catalan
 zh;Chinese


### PR DESCRIPTION
- Fix incorrect language code for Bengali in `app/ling/language_codes.txt`
- `nb` is the ISO 639-1 code for Norwegian Bokmal, not Bengali
- Bengali's correct code is `bn`

Fixes #171