### PR TITLE
Move db.session.commit() outside loops in utils_db.py

### DIFF
--- a/app/utils_db.py
+++ b/app/utils_db.py
@@ -142,9 +142,8 @@ def delete_pod_representations(pod_name):
     urls = db.session.query(Urls).filter_by(pod=pod_name).all()
     if urls is not None:
         for u in urls:
-            #This is going to be slow for many urls...
             db.session.delete(u)
-            db.session.commit()
+        db.session.commit()
     npz_path = join(pod_dir, contributor, lang, pod_name+'.npz')
     if isfile(npz_path):
         remove(npz_path)
@@ -296,7 +295,7 @@ def mv_pod(src, target, contributor=None):
         for url in urls:
             url.pod = target
             db.session.add(url)
-            db.session.commit()
+        db.session.commit()
     except:
         return "Renaming failed. Contact your administrator."
     return "Moved pod "+src.split('.u.')[0]+" to "+target.split('.u.')[0]


### PR DESCRIPTION
- Batch database commits instead of committing after each individual delete/update in a loop
- Fixed in `delete_pod_representations()` and `mv_pod()`
- More efficient and prevents partial state if an error occurs mid-loop

Fixes #169