### PR TITLE
Fix path traversal vulnerabilities in download and theme file paths

### DIFF
--- a/app/orchard/controllers.py
+++ b/app/orchard/controllers.py
@@ -4,7 +4,8 @@
 
 import logging
 # Import flask dependencies
-from flask import Blueprint, request, render_template, send_from_directory, flash, redirect, url_for
+from flask import Blueprint, request, render_template, send_from_directory, flash, redirect, url_for, abort
+from werkzeug.utils import secure_filename
 from flask_login import current_user
 from flask_babel import gettext
 from os.path import dirname, realpath, join
@@ -60,6 +61,11 @@ def get_a_pod():
 @check_permissions(login=True, confirmed=True, admin=True)
 def download_file():
     filename = request.args.get('filename')
+    if not filename:
+        abort(400)
+    filename = secure_filename(filename)
+    if not filename:
+        abort(400)
     logger.info("download_file: %s", filename)
     return send_from_directory(join(dir_path,'pods'), filename, as_attachment=True)
 

--- a/app/orchard/mk_urls_file.py
+++ b/app/orchard/mk_urls_file.py
@@ -5,6 +5,7 @@
 from os.path import dirname, realpath, join
 from os import getenv
 from flask import request
+from werkzeug.utils import secure_filename
 from app.api.models import Urls
 from flask import current_app
 
@@ -14,7 +15,7 @@ pod_dir = getenv("PODS_DIR", join(dir_path, 'pods'))
 
 def get_url_list_for_users(theme):
     urls = []
-    url_theme = theme.replace(' ', '_')
+    url_theme = secure_filename(theme.replace(' ', '_'))
     hfile = join(pod_dir, url_theme + ".pears.txt")
     f_out = open(hfile,'w', encoding='utf-8')
     for entry in Urls.query.filter(Urls.pod.contains(theme+'.u.')).all():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 PeARS Project, <community@pearsproject.org>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import os
+import pytest
+
+os.environ['_PEARS_CONFIG'] = 'testing'
+
+from app import app as flask_app
+
+
+@pytest.fixture
+def app():
+    flask_app.config.update({'TESTING': True})
+    yield flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 PeARS Project, <community@pearsproject.org>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from unittest.mock import patch, MagicMock
+from werkzeug.utils import secure_filename
+
+
+class TestDownloadFilePathTraversal:
+    """Tests for path traversal in download endpoint — issue #149."""
+
+    def test_unauthenticated_access_rejected(self, client):
+        """Download endpoint requires admin auth."""
+        resp = client.get('/download?filename=test.txt')
+        assert resp.status_code == 404
+
+    def test_secure_filename_strips_traversal_sequences(self):
+        """secure_filename removes ../ sequences."""
+        assert secure_filename('../../etc/passwd') == 'etc_passwd'
+        assert '..' not in secure_filename('../../etc/passwd')
+
+    def test_secure_filename_strips_absolute_paths(self):
+        """secure_filename removes leading slashes."""
+        assert secure_filename('/etc/passwd') == 'etc_passwd'
+
+    def test_secure_filename_returns_empty_for_dots_only(self):
+        """secure_filename returns empty string for pure traversal."""
+        assert secure_filename('../../') == ''
+        assert secure_filename('..') == ''
+
+
+class TestThemePathTraversal:
+    """Tests for path traversal in theme name — issue #157."""
+
+    def test_secure_filename_strips_traversal(self):
+        assert '..' not in secure_filename('../../etc/passwd')
+        assert '/' not in secure_filename('../../etc/passwd')
+
+    def test_secure_filename_preserves_valid_name(self):
+        assert secure_filename('My_Theme') == 'My_Theme'
+
+    def test_secure_filename_handles_slashes(self):
+        result = secure_filename('foo/bar/baz')
+        assert '/' not in result


### PR DESCRIPTION
- Sanitize filename in `download_file()` with `secure_filename()` and reject empty/traversal-only inputs with 400
- Sanitize theme name in `get_url_list_for_users()` with `secure_filename()` before using in file path construction
- Add tests for both fixes

Fixes #149, fixes #157