### PR TITLE
Preserve query string when switching language

### DIFF
--- a/app/templates/base/base.html
+++ b/app/templates/base/base.html
@@ -93,7 +93,7 @@ SPDX-License-Identifier: AGPL-3.0-only
             <ul id="lang-menu" class="lang-menu hidden" role="menu">
               {% for code, name in available_languages.items() %}
               <li role="menuitem">
-                <a href="{{url_for('settings.set_language', lang=code, current_page=request.path)}}"
+                <a href="{{url_for('settings.set_language', lang=code, current_page=request.full_path)}}"
                    {% if code == current_locale %}aria-current="true" class="active"{% endif %}>
                   {{ name }}
                 </a>


### PR DESCRIPTION
- Language switcher used `request.path` for the current page, which strips the query string
- Switching language on a page like `/orchard/get-a-pod?pod=home` redirected to `/orchard/get-a-pod` without the pod parameter, breaking the destination route
- Use `request.full_path` so the query string is preserved across the language switch