### PR TITLE
Speed up Docker CI: cache layers, skip push and multi-arch on PRs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 PeARS Project, <community@pearsproject.org>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 name: Docker Image CI
 
 on:
@@ -15,42 +19,41 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-    - name: Determine Docker tag
-      id: docker-tag
-      run: |
-        if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
-          echo "::set-output name=tag::latest"
-        elif [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "::set-output name=tag::pr-${{ github.event.number }}"
-        else
-          BRANCH_NAME=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///')
-          echo "::set-output name=tag::${BRANCH_NAME}"
-        fi
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-  
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      
-    - name: Build and push Docker image
+    - name: Build and push (main)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/build-push-action@v5
       with:
         context: .
         file: deployment/Dockerfile
         push: true
         platforms: linux/amd64,linux/arm64
-        tags: pearsproject/pears-federated:${{ steps.docker-tag.outputs.tag }}
+        tags: pearsproject/pears-federated:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
-    - name: Image digest
-      run: echo ${{ steps.build.outputs.digest }}
+    - name: Build only (PR)
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: deployment/Dockerfile
+        push: false
+        platforms: linux/amd64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - '*'
@@ -22,28 +24,39 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up QEMU
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name != 'pull_request'
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to Docker Hub
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-    - name: Build and push (main)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    - name: Determine Docker tags
+      id: meta
+      run: |
+        TAGS="pearsproject/pears-federated:latest"
+        TAGS="$TAGS,pearsproject/pears-federated:sha-${GITHUB_SHA::7}"
+        if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          TAGS="$TAGS,pearsproject/pears-federated:$VERSION"
+        fi
+        echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push (main / tag)
+      if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v5
       with:
         context: .
         file: deployment/Dockerfile
         push: true
         platforms: linux/amd64,linux/arm64
-        tags: pearsproject/pears-federated:latest
+        tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -2,15 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends poppler-utils && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt /tmp/
-RUN pip install --requirement /tmp/requirements.txt
+RUN pip install --no-cache-dir --requirement /tmp/requirements.txt gunicorn
 
-RUN apt update && apt install -y poppler-utils
-
-# Additionally, install Gunicorn
-RUN pip install gunicorn
-
-# Make port 8000 available to the world outside this container
 EXPOSE 8000
 
 ENV SQLALCHEMY_DATABASE_URI="sqlite:////var/lib/pears/data/app.db"
@@ -27,5 +23,4 @@ COPY . /app
 RUN chmod +x /app/deployment/entrypoint.sh
 RUN chmod +x /app/deployment/install-lang.py
 
-# Set the entrypoint script to be executed
 ENTRYPOINT ["/app/deployment/entrypoint.sh"]


### PR DESCRIPTION
Workflow changes:
- Only push to Docker Hub on main, build-only on PRs
- Only build multi-arch (amd64+arm64) on main, amd64-only on PRs (ARM builds via QEMU emulation are very slow)
- Add GitHub Actions cache for Docker layers
- Remove duplicate Buildx setup step
- Update actions to v3/v4
- Remove deprecated `set-output` syntax

Dockerfile changes:
- Move `apt-get` before `pip install` for better layer caching
- Add `--no-install-recommends` and clean up apt lists to reduce image size
- Combine pip install requirements and gunicorn into one layer
- Add `--no-cache-dir` to pip install