### PR TITLE
Fix DOM-XSS in theme dropdowns via innerHTML concat

### DIFF
--- a/app/templates/indexer/index.html
+++ b/app/templates/indexer/index.html
@@ -41,12 +41,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 </div>
 
 <script>
-  let themes = {{themes|tojson}};
-  let str = '';
-  for (theme of themes) {
-    str += '<option value="' + theme + '" />';
+  // Theme names come from the database and may contain HTML-special
+  // characters. Build <option> nodes via the DOM API so the browser
+  // escapes attribute values for us — never use innerHTML here.
+  const themes = {{themes|tojson}};
+  const themesList = document.getElementById("themes");
+  for (const theme of themes) {
+    const option = document.createElement("option");
+    option.value = theme;
+    themesList.appendChild(option);
   }
-  document.getElementById("themes").innerHTML = str;
 </script>
 
 {% endblock %}

--- a/app/templates/indexer/suggest.html
+++ b/app/templates/indexer/suggest.html
@@ -34,11 +34,15 @@ SPDX-License-Identifier: AGPL-3.0-only
 </div>
 
 <script>
-  let themes = {{themes|tojson}};
-  let str = '';
-  for (theme of themes) {
-    str += '<option value="' + theme + '" />';
+  // Theme names come from the database and may contain HTML-special
+  // characters. Build <option> nodes via the DOM API so the browser
+  // escapes attribute values for us — never use innerHTML here.
+  const themes = {{themes|tojson}};
+  const themesList = document.getElementById("themes");
+  for (const theme of themes) {
+    const option = document.createElement("option");
+    option.value = theme;
+    themesList.appendChild(option);
   }
-  document.getElementById("themes").innerHTML = str;
 </script>
 {% endblock %}

--- a/app/templates/indexer/web_commentary.html
+++ b/app/templates/indexer/web_commentary.html
@@ -44,12 +44,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 </div>
 
 <script>
-  let themes = {{themes|tojson}};
-  let str = '';
-  for (theme of themes) {
-    str += '<option value="' + theme + '" />';
+  // Theme names come from the database and may contain HTML-special
+  // characters. Build <option> nodes via the DOM API so the browser
+  // escapes attribute values for us — never use innerHTML here.
+  const themes = {{themes|tojson}};
+  const themesList = document.getElementById("themes");
+  for (const theme of themes) {
+    const option = document.createElement("option");
+    option.value = theme;
+    themesList.appendChild(option);
   }
-  document.getElementById("themes").innerHTML = str;
 </script>
 
 

--- a/app/templates/indexer/write_and_index.html
+++ b/app/templates/indexer/write_and_index.html
@@ -43,12 +43,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 </div>
 
 <script>
-  let themes = {{themes|tojson}};
-  let str = '';
-  for (theme of themes) {
-    str += '<option value="' + theme + '" />';
+  // Theme names come from the database and may contain HTML-special
+  // characters. Build <option> nodes via the DOM API so the browser
+  // escapes attribute values for us — never use innerHTML here.
+  const themes = {{themes|tojson}};
+  const themesList = document.getElementById("themes");
+  for (const theme of themes) {
+    const option = document.createElement("option");
+    option.value = theme;
+    themesList.appendChild(option);
   }
-  document.getElementById("themes").innerHTML = str;
 </script>
 
 {% endblock %}

--- a/tests/test_theme_xss.py
+++ b/tests/test_theme_xss.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 PeARS Project, <community@pearsproject.org>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Regression guard for issue #163 — innerHTML XSS in theme dropdowns.
+
+The bug: theme names were concatenated into an HTML string and assigned to
+`innerHTML`, so a theme name containing quotes or angle brackets could break
+the page or execute script.
+
+The fix switches to DOM-API construction (`document.createElement('option')`
++ `option.value = theme`) which the browser escapes automatically.
+
+This test greps the affected templates to catch any future regression where
+someone re-introduces string-concat + innerHTML for theme lists.
+"""
+
+import os
+import re
+
+import pytest
+
+TEMPLATE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "app",
+    "templates",
+    "indexer",
+)
+
+# Templates that render the theme datalist.
+THEME_TEMPLATES = [
+    "index.html",
+    "suggest.html",
+    "write_and_index.html",
+    "web_commentary.html",
+]
+
+
+class TestThemeDropdownXss:
+    @pytest.mark.parametrize("template", THEME_TEMPLATES)
+    def test_no_innerhtml_option_concat(self, template):
+        """Fail if the template builds <option> tags via string concat."""
+        path = os.path.join(TEMPLATE_DIR, template)
+        with open(path, "r", encoding="utf-8") as f:
+            source = f.read()
+
+        # The classic vulnerable pattern: building an HTML string with + and
+        # assigning it to innerHTML.
+        bad_patterns = [
+            r"\+\s*['\"]<option",           # "...  + '<option"
+            r"\.innerHTML\s*=\s*str\b",     # .innerHTML = str
+        ]
+        for pattern in bad_patterns:
+            assert not re.search(pattern, source), (
+                f"{template} contains the vulnerable pattern {pattern!r}. "
+                "Use document.createElement('option') + option.value = theme "
+                "instead of string concatenation with innerHTML."
+            )
+
+    @pytest.mark.parametrize("template", THEME_TEMPLATES)
+    def test_uses_createelement(self, template):
+        """Positive check: the template builds options via the DOM API."""
+        path = os.path.join(TEMPLATE_DIR, template)
+        with open(path, "r", encoding="utf-8") as f:
+            source = f.read()
+
+        assert 'createElement("option")' in source or \
+            "createElement('option')" in source, (
+                f"{template} should build theme options via "
+                "document.createElement('option')."
+            )


### PR DESCRIPTION
- Theme names from the database were concatenated into an HTML string and assigned to `innerHTML`, enabling DOM-based XSS via a malicious theme name
- Replaces the concat pattern with DOM-API construction (`document.createElement('option')` + `option.value = theme`) in all four affected templates: `index.html`, `suggest.html`, `write_and_index.html`, `web_commentary.html`
- Adds a regression-guard test that greps the templates for the vulnerable patterns and the corrected `createElement` call

Closes #163